### PR TITLE
Add multi-tool homepage and integrate Grip-Type assessor

### DIFF
--- a/asesor-grip-type.html
+++ b/asesor-grip-type.html
@@ -1,0 +1,585 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Asesor Grip-Type (Slip-on Joints) · LR Naval Ships</title>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ["Inter", "Segoe UI", "system-ui", "-apple-system", "sans-serif"],
+          },
+        },
+      },
+    };
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body class="bg-slate-900 text-slate-100 min-h-screen">
+  <div class="p-4">
+    <a href="index.html" class="inline-flex items-center gap-2 text-sm text-sky-300 hover:text-sky-100">
+      <span aria-hidden="true">←</span>
+      Volver al inicio
+    </a>
+  </div>
+  <div id="root"></div>
+
+  <script type="text/babel" data-presets="env,react">
+    const { useState } = React;
+
+    const SearchIcon = ({ className = "w-4 h-4", ...props }) => (
+      <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+        <circle cx="11" cy="11" r="7"></circle>
+        <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+      </svg>
+    );
+
+    const ShieldIcon = ({ className = "w-6 h-6", ...props }) => (
+      <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+        <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
+      </svg>
+    );
+
+    function App() {
+      const CLASS_LIMITS = {
+        steam: { classII: { P: 16, T: 300 }, classIII: { P: 7, T: 170 } },
+        thermal_oil: { classII: { P: 16, T: 300 }, classIII: { P: 7, T: 150 } },
+        flammable_liquids: { classII: { P: 16, T: 150 }, classIII: { P: 7, T: 60 } },
+        other_media: { classII: { P: 40, T: 300 }, classIII: { P: 16, T: 200 } },
+      };
+
+      const TABLE_NOTES_ES = {
+        "1": "Las juntas mecánicas que incluyan componentes que se deterioran fácilmente en caso de incendio deben ser de tipo resistente al fuego aprobado cuando se instalen en espacios de maquinaria de Categoría A. Los acoplamientos del ‘bilge main’ en espacios de Categoría A deben ser de acero, CuNi o material equivalente.",
+        "2": "Los slip‑on joints no se aceptan dentro de espacios de maquinaria de Categoría A, depósitos de munición ni espacios de alojamiento. Se aceptan en otros espacios de maquinaria y servicio siempre que queden en posiciones fácilmente visibles y accesibles.",
+        "3": "Las juntas mecánicas deben ser de tipo resistente al fuego aprobado, salvo cuando estén en cubiertas abiertas con poco o ningún riesgo de incendio según SOLAS II‑2/9.2.3.3.2.2(10).",
+        "4": "Las juntas mecánicas deben ser de tipo resistente al fuego aprobado.",
+        "5": "Ver Vol 2, Pt 7, Ch 1, 5.10 – Other mechanical couplings (remisión normativa).",
+        "6": "Las juntas mecánicas solo se permiten por encima del límite de integridad estanca (WTI).",
+        "7": "Requisitos para HVAC trunking y para entradas/salidas de turbina de gas se tratan en las secciones correspondientes de las Reglas.",
+      };
+
+      const NAVAL_SYSTEMS = [
+        { id: "ff_le60_aircraft_vehicle_fuel", group: "Flammable fluids (flash point ≤ 60°C)", system: "Aircraft and vehicle fuel oil lines", mediumGroup: "flammable_liquids", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "30 min dry (*)", notes: ["Notes 2 & 4"] },
+        { id: "ff_le60_vent_lines", group: "Flammable fluids (flash point ≤ 60°C)", system: "Vent lines", mediumGroup: "flammable_liquids", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "30 min dry (*)", notes: ["Notes 2 & 3"] },
+        { id: "ff_gt60_aircraft_vehicle_fuel", group: "Flammable fluids (flash point > 60°C)", system: "Aircraft and vehicle fuel oil lines", mediumGroup: "flammable_liquids", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "30 min dry (*)", notes: ["Notes 2 & 4"] },
+        { id: "ff_gt60_ship_machinery_fuel", group: "Flammable fluids (flash point > 60°C)", system: "Ship’s machinery fuel oil lines", mediumGroup: "flammable_liquids", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "30 min wet (*)", notes: ["Notes 2 & 3"] },
+        { id: "ff_gt60_lubricating_oil", group: "Flammable fluids (flash point > 60°C)", system: "Lubricating oil lines", mediumGroup: "flammable_liquids", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "30 min wet (*)", notes: ["Notes 2 & 3"] },
+        { id: "ff_gt60_hydraulic_oil", group: "Flammable fluids (flash point > 60°C)", system: "Hydraulic oil", mediumGroup: "flammable_liquids", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "30 min wet (*)", notes: ["Notes 2 & 3"] },
+        { id: "sw_bilge", group: "Sea water", system: "Bilge lines", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry/wet", fireTest: "8 min dry + 22 min wet (*)", notes: ["Note 1"] },
+        { id: "sw_hp_spray", group: "Sea water", system: "HP sea water and water spray (not permanently filled)", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry/wet", fireTest: "8 min dry + 22 min wet (*)" },
+        { id: "sw_perm_fireext", group: "Sea water", system: "Permanent water filled fire‑extinguishing systems (fire main, sprinklers)", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "30 min wet (*)", notes: ["Note 3"] },
+        { id: "sw_nonperm_fireext", group: "Sea water", system: "Non‑permanent water filled fire‑extinguishing systems (foam, drencher, fire main)", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry/wet", fireTest: "8 min dry + 22 min wet (*) – Foam: comply FSS Code", notes: ["Note 3"] },
+        { id: "sw_ballast", group: "Sea water", system: "Ballast system", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "8 min dry + 22 min wet (*)", notes: ["Note 1"] },
+        { id: "sw_cooling", group: "Sea water", system: "Cooling water system", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "8 min dry + 22 min wet (*)", notes: ["Note 1"] },
+        { id: "sw_tank_cleaning", group: "Sea water", system: "Tank cleaning services", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "Fire endurance test not required" },
+        { id: "sw_non_essential", group: "Sea water", system: "Non‑essential systems", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "Fire endurance test not required" },
+        { id: "fw_cooling", group: "Fresh water", system: "Cooling water system", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "Fire endurance test not required", notes: ["Note 1"] },
+        { id: "fw_chilled", group: "Fresh water", system: "Chilled water system", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "Except chilled water: 30 min wet (*)", notes: ["Note 1"] },
+        { id: "fw_condensate", group: "Fresh water", system: "Condensate return", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "Fire endurance test not required", notes: ["Note 1"] },
+        { id: "fw_made_demin", group: "Fresh water", system: "Made & demineralised water system", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "Fire endurance test not required" },
+        { id: "fw_ancillary", group: "Fresh water", system: "Ancillary system", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "Fire endurance test not required" },
+        { id: "san_deck_drains", group: "Sanitary / drains / scuppers", system: "Deck drains (internal)", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "Fire endurance test not required", notes: ["Note 6"] },
+        { id: "san_sanitary_drains", group: "Sanitary / drains / scuppers", system: "Sanitary drains", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "Fire endurance test not required" },
+        { id: "san_scuppers_overboard", group: "Sanitary / drains / scuppers", system: "Scuppers & discharge (overboard)", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: false }, pipeSystemClass: "dry", fireTest: "Fire endurance test not required" },
+        { id: "sv_water_tanks_dry", group: "Sounding / vent", system: "Water tanks / dry spaces", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry/wet", fireTest: "Fire endurance test not required" },
+        { id: "sv_oil_tanks", group: "Sounding / vent", system: "Oil tanks (f.p. > 60°C)", mediumGroup: "flammable_liquids", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "Fire endurance test not required", notes: ["Notes 2 & 3"] },
+        { id: "sv_intakes_uptakes", group: "Sounding / vent", system: "Intakes and uptakes", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "Fire endurance test not required", notes: ["Note 7"] },
+        { id: "sv_hvac", group: "Sounding / vent", system: "HVAC trunking", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "Fire endurance test not required", notes: ["Note 7"] },
+        { id: "misc_air_hp", group: "Miscellaneous", system: "High pressure (HP) air system", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "30 min dry (*)", notes: ["Note 1"] },
+        { id: "misc_air_mp", group: "Miscellaneous", system: "Medium pressure (MP) air system", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "30 min dry (*)", notes: ["Note 1"] },
+        { id: "misc_air_lp", group: "Miscellaneous", system: "Low pressure (LP) air system", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "Fire endurance test not required", notes: ["Note 1"] },
+        { id: "misc_service_air_nonessential", group: "Miscellaneous", system: "Service air (non‑essential)", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "Fire endurance test not required" },
+        { id: "misc_brine", group: "Miscellaneous", system: "Brine", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "Fire endurance test not required" },
+        { id: "misc_co2", group: "Miscellaneous", system: "CO₂ system", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: false }, pipeSystemClass: "dry", fireTest: "30 min dry (*)", notes: ["Note 1"] },
+        { id: "misc_n2", group: "Miscellaneous", system: "Nitrogen system", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: false }, pipeSystemClass: "dry", fireTest: "30 min dry (*)" },
+        { id: "misc_steam", group: "Miscellaneous", system: "Steam", mediumGroup: "steam", allowed: { pipeUnions: true, compression: true, slipOn: false }, pipeSystemClass: "-", fireTest: "Fire endurance test not required", notes: ["See Note 5 / special consideration"] },
+      ];
+
+      const COUPLING_RULES = {
+        pipeUnions: (clazz, odMM) => {
+          if (clazz === "III") return { allowed: true, reason: "+ (sin límite de OD en Class III)" };
+          const ok = odMM <= 60.3;
+          return { allowed: ok, reason: ok ? "+ (OD ≤ 60.3 mm en Class I/II)" : "Table 1.5.4: En Class I/II solo OD ≤ 60.3 mm" };
+        },
+        compressionSubtypes: (clazz, odMM) => ({
+          swage: clazz === "III",
+          bite: clazz === "III" ? true : odMM <= 60.3,
+          typical: clazz === "III" ? true : odMM <= 60.3,
+          flared: clazz === "III" ? true : odMM <= 60.3,
+          press: clazz === "III",
+        }),
+        slipOnSubtypes: (clazz) => ({
+          machine_grooved: true,
+          grip: clazz !== "I",
+          slip: clazz !== "I",
+        }),
+      };
+
+      const [selectedSystemId, setSelectedSystemId] = useState(NAVAL_SYSTEMS[0].id);
+      const [classMode, setClassMode] = useState("manual");
+      const [clazz, setClazz] = useState("II");
+      const [odMM, setOdMM] = useState(50);
+      const [designPressureBar, setDesignPressureBar] = useState(7.5);
+      const [designTemperatureC, setDesignTemperatureC] = useState(25);
+      const [space, setSpace] = useState("other_machinery");
+      const [belowWTI, setBelowWTI] = useState(false);
+      const [insideTank, setInsideTank] = useState(false);
+      const [sameMediumTank, setSameMediumTank] = useState(false);
+      const [evaluation, setEvaluation] = useState(null);
+      const [viewer, setViewer] = useState(null);
+
+      function suggestClass(mediumGroup, P, T) {
+        const lim = CLASS_LIMITS[mediumGroup];
+        if (!lim) return "II";
+        if (P > lim.classII.P || T > lim.classII.T) return "I";
+        if (P > lim.classIII.P || T > lim.classIII.T) return "II";
+        return "III";
+      }
+
+      function computeUsedClass(sys) {
+        if (classMode === "manual") return clazz;
+        return suggestClass(sys.mediumGroup, designPressureBar, designTemperatureC);
+      }
+
+      function expandSystemNotes(notes) {
+        if (!notes) return [];
+        const out = [];
+        for (const n of notes) {
+          const nums = n.match(/[0-9]+/g) || [];
+          for (const code of nums) {
+            if (TABLE_NOTES_ES[code]) out.push(`Nota ${code}: ${TABLE_NOTES_ES[code]}`);
+          }
+        }
+        return out;
+      }
+
+      function buildComplianceNotes(sys, usedClass, catNotes) {
+        const notes = [];
+        if (sys.fireTest && !/not required/i.test(sys.fireTest)) {
+          notes.push(`Requiere ensayo de resistencia al fuego: ${sys.fireTest}.`);
+          notes.push("La junta seleccionada debe ser de tipo **resistente al fuego aprobado**.");
+        } else {
+          notes.push(`Ensayo de resistencia al fuego: **no requerido** (según la fila del sistema).`);
+        }
+
+        notes.push(...expandSystemNotes(sys.notes));
+
+        if (space === "other_machinery") {
+          notes.push("Si se emplean slip‑on joints en este espacio: deben estar en **posiciones visibles y accesibles** (Nota 2).");
+        }
+
+        if (["cargo_hold", "tank"].includes(space)) {
+          if (!(insideTank && sameMediumTank)) notes.push("5.10.9: Slip‑on joints no en bodegas/tanques o espacios no accesibles; dentro de tanques solo si el medio es el mismo.");
+        }
+
+        notes.push("5.10.10: El tipo Slip no debe usarse como medio principal de conexión (salvo compensación axial).");
+        notes.push("5.10.5: Las juntas mecánicas deben resistir presión de rotura ≥ 4 × presión de diseño.");
+        notes.push("5.10.12: Ensayos de tipo conforme a LR Type Approval Test Spec No. 2, según servicio.");
+
+        if (belowWTI) notes.push("5.10.6: Prohibidas juntas mecánicas si el tramo está conectado directamente al costado por debajo del límite de integridad estanca.");
+
+        const isSteam = sys.system.toLowerCase() === "steam" || sys.mediumGroup === "steam";
+        if (isSteam && designPressureBar <= 10 && space === "open_deck") notes.push("5.10.11: En buques tanque (oil/chemical), permitido 'restrained slip‑on' para vapor ≤ 10 bar en cubierta expuesta para absorber movimiento axial.");
+
+        notes.push(`Clase utilizada: Class ${usedClass}${classMode === "auto" ? " (derivada por P/T)" : " (seleccionada por usuario)"}.`);
+
+        notes.push(...catNotes);
+        return notes;
+      }
+
+      function evaluate() {
+        const sys = NAVAL_SYSTEMS.find((s) => s.id === selectedSystemId) || NAVAL_SYSTEMS[0];
+        const usedClass = computeUsedClass(sys);
+
+        const base = { ...sys.allowed };
+
+        const allowAfterLocation = { ...base };
+        const catNotes = [];
+
+        if (belowWTI) {
+          const reasons = ["5.10.6: Prohibido en tramos directamente conectados al costado por debajo del límite de integridad estanca."];
+          setEvaluation({ sys, usedClass, categories: { pipeUnions: false, compression: false, slipOn: false }, reasons, details: {}, notes: buildComplianceNotes(sys, usedClass, catNotes) });
+          return;
+        }
+
+        if (["category_a", "accommodation", "munition_store"].includes(space)) {
+          allowAfterLocation.slipOn = false;
+          catNotes.push("Nota 2: Slip‑on bloqueado por la ubicación seleccionada.");
+        }
+        if (["cargo_hold", "tank"].includes(space) && !(insideTank && sameMediumTank)) {
+          allowAfterLocation.slipOn = false;
+          catNotes.push("5.10.9: Slip‑on bloqueado en bodegas/tanques (salvo mismo medio dentro del tanque).");
+        }
+
+        let pipeUnionsAllowed = allowAfterLocation.pipeUnions;
+        let pipeUnionsRule = { allowed: false, reason: "" };
+        if (pipeUnionsAllowed) {
+          pipeUnionsRule = COUPLING_RULES.pipeUnions(usedClass, odMM);
+          pipeUnionsAllowed = pipeUnionsAllowed && pipeUnionsRule.allowed;
+          if (!pipeUnionsRule.allowed) catNotes.push(pipeUnionsRule.reason);
+        }
+
+        let compressionAllowed = allowAfterLocation.compression;
+        let compressionSubs = { swage: false, bite: false, typical: false, flared: false, press: false };
+        if (compressionAllowed) {
+          compressionSubs = COUPLING_RULES.compressionSubtypes(usedClass, odMM);
+          const anySub = Object.values(compressionSubs).some(Boolean);
+          compressionAllowed = compressionAllowed && anySub;
+          if (!anySub) catNotes.push(`Table 1.5.4: En Class ${usedClass}${usedClass !== "III" ? ` y OD ${odMM} mm` : ""} no queda ningún subtipo de compression permitido.`);
+          if (usedClass !== "III" && odMM > 60.3) catNotes.push("Table 1.5.4: En Class I/II, Bite/Typical/Flared solo OD ≤ 60.3 mm.");
+          if (usedClass !== "III") catNotes.push("Table 1.5.4: Swage/Press solo en Class III.");
+        }
+
+        let slipOnAllowed = allowAfterLocation.slipOn;
+        let slipOnSubs = { machine_grooved: false, grip: false, slip: false };
+        if (slipOnAllowed) {
+          slipOnSubs = COUPLING_RULES.slipOnSubtypes(usedClass);
+          const anySub = Object.values(slipOnSubs).some(Boolean);
+          slipOnAllowed = slipOnAllowed && anySub;
+          if (!slipOnSubs.grip || !slipOnSubs.slip) catNotes.push("Table 1.5.4: Grip/Slip no se permiten en Class I.");
+        }
+
+        const categories = { pipeUnions: pipeUnionsAllowed, compression: compressionAllowed, slipOn: slipOnAllowed };
+
+        const details = {
+          pipeUnionsRule,
+          compressionSubs,
+          slipOnSubs,
+          odMM,
+          design: { P: designPressureBar, T: designTemperatureC },
+          classMode,
+          suggestedClass: suggestClass(sys.mediumGroup, designPressureBar, designTemperatureC),
+        };
+
+        const reasons = [];
+        if (!categories.slipOn && base.slipOn) reasons.push("Slip‑on permitido por 1.5.3, pero bloqueado por ubicación (Nota 2 / 5.10.9) o por clase en 1.5.4.");
+
+        setEvaluation({ sys, usedClass, categories, reasons, details, notes: buildComplianceNotes(sys, usedClass, catNotes) });
+      }
+
+      const sys = NAVAL_SYSTEMS.find((s) => s.id === selectedSystemId) || NAVAL_SYSTEMS[0];
+      const usedClass = computeUsedClass(sys);
+
+      return (
+        <div className="min-h-screen bg-gradient-to-b from-slate-900 to-slate-800 text-slate-100">
+          <header className="sticky top-0 z-10 backdrop-blur bg-slate-900/70 border-b border-slate-700">
+            <div className="max-w-7xl mx-auto px-4 py-3 flex items-center gap-3">
+              <ShieldIcon className="w-6 h-6" />
+              <h1 className="text-xl font-semibold">Asesor Grip‑Type LR (Slip‑on Joints) – v0.7 · Naval Ships</h1>
+              <span className="ml-auto hidden md:block text-sm text-slate-300">Lógica: 1.5.3 → ubicación → 1.5.4 (clase/OD). Notas en español.</span>
+            </div>
+          </header>
+
+          <main className="max-w-7xl mx-auto p-4 space-y-6">
+            <section className="bg-slate-950/40 rounded-2xl p-4 shadow space-y-4">
+              <div className="grid md:grid-cols-2 gap-4">
+                <Field label="Sistema (Table 1.5.3)">
+                  <select className="w-full bg-slate-800 border border-slate-600 rounded-xl px-3 py-2" value={selectedSystemId} onChange={(e) => setSelectedSystemId(e.target.value)}>
+                    {Array.from(new Set(NAVAL_SYSTEMS.map((s) => s.group))).map((grp) => (
+                      <optgroup key={grp} label={grp}>
+                        {NAVAL_SYSTEMS.filter((s) => s.group === grp).map((s) => (
+                          <option key={s.id} value={s.id}>
+                            {s.system}
+                          </option>
+                        ))}
+                      </optgroup>
+                    ))}
+                  </select>
+                </Field>
+                <Field label="Espacio / Ubicación">
+                  <select className="w-full bg-slate-800 border border-slate-600 rounded-xl px-3 py-2" value={space} onChange={(e) => setSpace(e.target.value)}>
+                    <option value="category_a">Category A machinery space</option>
+                    <option value="other_machinery">Other machinery/service spaces (accesible & visible)</option>
+                    <option value="accommodation">Accommodation spaces</option>
+                    <option value="munition_store">Munition stores</option>
+                    <option value="cargo_hold">Cargo hold</option>
+                    <option value="tank">Inside tank</option>
+                    <option value="open_deck">Open/Weather deck</option>
+                  </select>
+                </Field>
+              </div>
+
+              <div className="grid md:grid-cols-2 gap-4">
+                <Field label="Modo de clase">
+                  <div className="flex items-center gap-3">
+                    <button onClick={() => setClassMode("manual")} className={`px-3 py-1 rounded-full border ${classMode === "manual" ? "bg-slate-700 border-slate-500" : "border-slate-600"}`}>
+                      Seleccionar clase
+                    </button>
+                    <button onClick={() => setClassMode("auto")} className={`px-3 py-1 rounded-full border ${classMode === "auto" ? "bg-slate-700 border-slate-500" : "border-slate-600"}`}>
+                      Calcular por P/T
+                    </button>
+                    <span className="text-xs text-slate-400">Class I es la más exigente; usa AUTO si quieres derivarla desde P/T (Tabla 1.2.1).</span>
+                  </div>
+                </Field>
+                {classMode === "manual" ? (
+                  <Field label="Clase de tubería (Table 1.5.4)">
+                    <select className="w-full bg-slate-800 border border-slate-600 rounded-xl px-3 py-2" value={clazz} onChange={(e) => setClazz(e.target.value)}>
+                      <option value="I">Class I</option>
+                      <option value="II">Class II</option>
+                      <option value="III">Class III</option>
+                    </select>
+                  </Field>
+                ) : (
+                  <div className="grid grid-cols-2 gap-3">
+                    <Field label="P diseño [bar]">
+                      <input type="number" step="0.1" className="w-full bg-slate-800 border border-slate-600 rounded-xl px-3 py-2" value={designPressureBar} onChange={(e) => setDesignPressureBar(Number(e.target.value))} />
+                    </Field>
+                    <Field label="T diseño [°C]">
+                      <input type="number" className="w-full bg-slate-800 border border-slate-600 rounded-xl px-3 py-2" value={designTemperatureC} onChange={(e) => setDesignTemperatureC(Number(e.target.value))} />
+                    </Field>
+                  </div>
+                )}
+              </div>
+
+              <div className="grid md:grid-cols-3 gap-4">
+                <Field label="Diámetro exterior OD [mm]">
+                  <input type="number" className="w-full bg-slate-800 border border-slate-600 rounded-xl px-3 py-2" value={odMM} onChange={(e) => setOdMM(Number(e.target.value))} />
+                </Field>
+                <Toggle label="Conexión directa al costado por debajo del límite WTI (5.10.6)" value={belowWTI} onChange={setBelowWTI} />
+                <div className="grid grid-cols-2 gap-3">
+                  <Toggle label="¿Dentro de tanque? (5.10.9)" value={insideTank} onChange={setInsideTank} />
+                  <Toggle label="Si está en tanque: ¿medio igual al del tanque? (excepción 5.10.9)" value={sameMediumTank} onChange={setSameMediumTank} />
+                </div>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-3">
+                <button onClick={evaluate} className="inline-flex items-center gap-2 bg-emerald-400 text-emerald-950 font-semibold px-3 py-2 rounded-xl hover:bg-emerald-300">
+                  <SearchIcon className="w-4 h-4" /> Evaluar
+                </button>
+                <div className="text-xs text-slate-300">
+                  Clase utilizada ahora: <b>Class {usedClass}</b> {classMode === "auto" && `(calculada por P/T para ${sys.mediumGroup})`}
+                </div>
+              </div>
+            </section>
+
+            <section className="bg-slate-950/40 rounded-2xl p-4 shadow space-y-4">
+              {!evaluation ? (
+                <p className="text-slate-400 text-sm">Configura y pulsa Evaluar para ver las uniones permitidas y notas normativas (en español).</p>
+              ) : (
+                <div className="space-y-4">
+                  <div className="text-sm text-slate-300">
+                    Sistema: <b>{evaluation.sys.group} → {evaluation.sys.system}</b> · Condición del sistema (tabla): <b>{evaluation.sys.pipeSystemClass}</b> · Ensayo fuego: <b>{evaluation.sys.fireTest}</b>
+                  </div>
+
+                  <div className="grid md:grid-cols-3 gap-4">
+                    <CategoryCard
+                      title="Pipe unions"
+                      allowed={evaluation.categories.pipeUnions}
+                      details={evaluation.details.pipeUnionsRule?.reason}
+                      items={[{ label: "Welded/Brazed", kind: "pipe_welded_brazed", available: evaluation.categories.pipeUnions }]}
+                      onView={(kind) => setViewer({ open: true, title: "Pipe unions – welded/brazed", kind })}
+                    />
+
+                    <CategoryCard
+                      title="Compression couplings"
+                      allowed={evaluation.categories.compression}
+                      details={evaluation.categories.compression ? "Subtipos según clase y OD" : "Sin subtipos válidos con la clase/OD"}
+                      items={[
+                        { label: "Swage", kind: "compression_swage", available: evaluation.details.compressionSubs.swage },
+                        { label: "Bite", kind: "compression_bite", available: evaluation.details.compressionSubs.bite },
+                        { label: "Typical", kind: "compression_typical", available: evaluation.details.compressionSubs.typical },
+                        { label: "Flared", kind: "compression_flared", available: evaluation.details.compressionSubs.flared },
+                        { label: "Press", kind: "compression_press", available: evaluation.details.compressionSubs.press },
+                      ]}
+                      onView={(kind) => setViewer({ open: true, title: `Compression – ${kind.split("_")[1]}`, kind })}
+                    />
+
+                    <CategoryCard
+                      title="Slip‑on joints"
+                      allowed={evaluation.categories.slipOn}
+                      details={evaluation.categories.slipOn ? "Machine‑grooved / Grip / Slip" : "Bloqueado por ubicación o clase"}
+                      items={[
+                        { label: "Machine grooved", kind: "slip_machine_grooved", available: evaluation.details.slipOnSubs.machine_grooved },
+                        { label: "Grip type", kind: "slip_grip", available: evaluation.details.slipOnSubs.grip },
+                        { label: "Slip type", kind: "slip_slip", available: evaluation.details.slipOnSubs.slip },
+                      ]}
+                      onView={(kind) => setViewer({ open: true, title: `Slip‑on – ${kind.split("_")[1]}`, kind })}
+                    />
+                  </div>
+
+                  <div className="text-sm bg-slate-900 border border-slate-700 rounded-xl p-3">
+                    <div className="font-semibold mb-1">Notas y condiciones que aplican</div>
+                    <ul className="list-disc list-inside">
+                      {evaluation.notes.map((n, i) => (
+                        <li key={i}>{n}</li>
+                      ))}
+                    </ul>
+                  </div>
+
+                  <div className="text-xs text-slate-400">
+                    Grupo de medio: <b>{sys.mediumGroup}</b>. Límites Class II: P≤{CLASS_LIMITS[sys.mediumGroup].classII.P} bar / T≤{CLASS_LIMITS[sys.mediumGroup].classII.T} °C; Class III: P≤{CLASS_LIMITS[sys.mediumGroup].classIII.P} bar / T≤{CLASS_LIMITS[sys.mediumGroup].classIII.T} °C. Si P/T superan Class II, norma exige Class I (2.3.2).
+                  </div>
+                </div>
+              )}
+            </section>
+
+            <footer className="pb-10 text-xs text-slate-400">v0.7 • Naval Ships – Motor de decisión con notas en español y visor de referencias gráficas (SVG) por tipo de unión.</footer>
+          </main>
+
+          {viewer?.open && (
+            <div className="fixed inset-0 z-50 bg-black/70 flex items-center justify-center p-4" onClick={() => setViewer(null)}>
+              <div className="bg-slate-900 border border-slate-700 rounded-2xl p-4 max-w-2xl w-full" onClick={(e) => e.stopPropagation()}>
+                <div className="flex items-center mb-3">
+                  <h3 className="text-lg font-semibold">{viewer.title}</h3>
+                  <button className="ml-auto px-3 py-1 rounded-lg bg-slate-800 border border-slate-600" onClick={() => setViewer(null)}>
+                    Cerrar
+                  </button>
+                </div>
+                <div className="bg-slate-800 rounded-xl p-4 flex items-center justify-center">
+                  {renderJointSVG(viewer.kind)}
+                </div>
+                <div className="text-xs text-slate-400 mt-2">Esquema referencial estilizado a partir de Fig. 1.5.4/1.5.5. Cuando dispongamos de las imágenes oficiales se sustituyen aquí sin cambiar el flujo.</div>
+              </div>
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    function Field({ label, children }) {
+      return (
+        <label className="block text-sm">
+          <div className="mb-1 text-slate-300">{label}</div>
+          {children}
+        </label>
+      );
+    }
+
+    function Toggle({ label, value, onChange }) {
+      return (
+        <div className="flex items-center justify-between px-3 py-2 bg-slate-800/60 border border-slate-600 rounded-xl">
+          <span className="text-sm text-slate-200">{label}</span>
+          <button
+            onClick={() => onChange(!value)}
+            className={`w-12 h-7 rounded-full transition-colors ${value ? "bg-emerald-400" : "bg-slate-600"}`}
+            aria-pressed={value}
+          >
+            <span className={`block w-6 h-6 bg-white rounded-full mt-0.5 transition-transform ${value ? "translate-x-5" : "translate-x-1"}`} />
+          </button>
+        </div>
+      );
+    }
+
+    function CategoryCard({ title, allowed, details, items, onView }) {
+      return (
+        <div className={`rounded-xl p-3 border ${allowed ? "border-emerald-700 bg-emerald-900/20" : "border-rose-700 bg-rose-900/20"}`}>
+          <div className="font-semibold mb-1">{title}</div>
+          <div className="text-sm mb-2">{allowed ? "Se puede usar" : "No se puede usar"}{details ? ` • ${details}` : ""}</div>
+          {items && (
+            <ul className="text-sm space-y-1">
+              {items.map((it, idx) => (
+                <li key={idx} className="flex items-center gap-2">
+                  <span className={it.available ? "" : "line-through opacity-60"}>{it.label}</span>
+                  {it.available && (
+                    <button className="text-xs px-2 py-0.5 rounded-lg border border-slate-600 hover:bg-slate-700" onClick={() => onView(it.kind)}>
+                      ver
+                    </button>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      );
+    }
+
+    function renderJointSVG(kind) {
+      const common = { width: 520, height: 160, viewBox: "0 0 520 160" };
+      const line = (x1, y1, x2, y2, extra = {}) => <line x1={x1} y1={y1} x2={x2} y2={y2} stroke="white" strokeWidth={3} {...extra} />;
+      const rect = (x, y, w, h, extra = {}) => <rect x={x} y={y} width={w} height={h} fill="none" stroke="white" strokeWidth={3} {...extra} />;
+      const path = (d, extra = {}) => <path d={d} fill="none" stroke="white" strokeWidth={3} {...extra} />;
+      switch (kind) {
+        case "pipe_welded_brazed":
+          return (
+            <svg {...common}>
+              {line(40, 80, 240, 80)}
+              {line(280, 80, 480, 80)}
+              {path("M240 80 L260 50 L280 80", {})}
+            </svg>
+          );
+        case "compression_swage":
+          return (
+            <svg {...common}>
+              {line(40, 80, 200, 80)}
+              {line(320, 80, 480, 80)}
+              {rect(200, 60, 120, 40)}
+              {path("M200 60 L210 40 L310 40 L320 60", {})}
+            </svg>
+          );
+        case "compression_bite":
+          return (
+            <svg {...common}>
+              {line(40, 80, 200, 80)}
+              {line(320, 80, 480, 80)}
+              {rect(200, 55, 120, 50)}
+              {path("M220 105 L220 55", {})}
+              {path("M300 105 L300 55", {})}
+              {path("M240 80 L280 80", {})}
+            </svg>
+          );
+        case "compression_typical":
+          return (
+            <svg {...common}>
+              {line(40, 80, 200, 80)}
+              {line(320, 80, 480, 80)}
+              {rect(200, 55, 120, 50)}
+              {rect(230, 40, 60, 30)}
+            </svg>
+          );
+        case "compression_flared":
+          return (
+            <svg {...common}>
+              {line(40, 80, 210, 80)}
+              {line(310, 80, 480, 80)}
+              {path("M210 80 Q260 40 310 80", {})}
+            </svg>
+          );
+        case "compression_press":
+          return (
+            <svg {...common}>
+              {line(40, 90, 480, 90)}
+              {rect(220, 50, 80, 40)}
+              {path("M220 50 L210 30", {})}
+              {path("M300 50 L310 30", {})}
+            </svg>
+          );
+        case "slip_machine_grooved":
+          return (
+            <svg {...common}>
+              {line(40, 100, 480, 100)}
+              {rect(210, 60, 100, 40)}
+              {path("M210 60 L260 30 L310 60", {})}
+            </svg>
+          );
+        case "slip_grip":
+          return (
+            <svg {...common}>
+              {line(40, 100, 480, 100)}
+              {rect(200, 60, 120, 40)}
+              {path("M210 60 L260 30 L310 60", {})}
+              {path("M220 85 Q260 65 300 85", {})}
+            </svg>
+          );
+        case "slip_slip":
+          return (
+            <svg {...common}>
+              {line(40, 100, 480, 100)}
+              {rect(210, 60, 100, 40)}
+              {rect(230, 85, 60, 25)}
+            </svg>
+          );
+        default:
+          return <div className="text-slate-300">(Referencia no disponible)</div>;
+      }
+    }
+
+    const root = ReactDOM.createRoot(document.getElementById("root"));
+    root.render(<App />);
+  </script>
+</body>
+</html>

--- a/compatibilidad.html
+++ b/compatibilidad.html
@@ -1,0 +1,323 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Compatibilidad de tuberías a través de tanques · Norma cerrada</title>
+<style>
+  :root{--ok:#16a34a;--bad:#dc2626;--warn:#d97706;--ink:#0f172a;--mut:#64748b;--bg:#f8fafc;--card:#ffffff}
+  html,body{margin:0;background:var(--bg);color:var(--ink);font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,'Helvetica Neue',Arial,'Noto Sans',sans-serif}
+  .wrap{max-width:1200px;margin:auto;padding:22px}
+  h1{font-size:22px;margin:0 0 8px}
+  .grid{display:grid;grid-template-columns:1.15fr 1fr;gap:18px}
+  .card{background:var(--card);border-radius:16px;box-shadow:0 10px 25px rgba(2,8,23,.06);padding:16px}
+  .row{display:grid;grid-template-columns:1fr 1fr;gap:10px}
+  label{font-size:12px;font-weight:700;color:#334155;display:block;margin-bottom:6px}
+  select,input{width:100%;padding:10px 12px;border:1px solid #e2e8f0;border-radius:10px;background:#fff;font-size:14px}
+  .hint{font-size:12px;color:var(--mut);margin-top:6px}
+  .pill{display:inline-flex;align-items:center;gap:6px;border-radius:999px;padding:6px 10px;font-weight:700;font-size:12px}
+  .pill.ok{background:#dcfce7;color:#065f46}
+  .pill.bad{background:#fee2e2;color:#991b1b}
+  .pill.warn{background:#fef3c7;color:#92400e}
+  .mono{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,'Liberation Mono',monospace}
+  .svgbox{position:relative;width:100%;aspect-ratio: 4/3;background:linear-gradient(180deg,#f1f5f9, #eef2ff)}
+  .legend{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px}
+  .tbl{width:100%;border-collapse:collapse;font-size:13px;margin-top:10px}
+  .tbl th,.tbl td{border:1px solid #e2e8f0;padding:8px}
+  .tbl th{background:#f1f5f9;text-align:left}
+  .small{font-size:12px;color:#475569}
+  .badge{display:inline-block;background:#eef2ff;color:#3730a3;border:1px solid #c7d2fe;padding:3px 6px;border-radius:999px;font-size:11px}
+  footer{margin-top:18px;font-size:12px;color:#475569}
+  .tests{font-size:12px;line-height:1.2}
+  .tests b{font-weight:800}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <nav style="margin-bottom:18px"><a href="index.html" style="color:#2563eb;text-decoration:none;font-weight:600">← Volver al inicio</a></nav>
+  <h1>¿Puede pasar una <em>tubería</em> a través de una <em>ubicación</em>?</h1>
+  <p class="small">Norma referencia GL (Tabla 11.5) y espesores mínimos por material (Tablas 11.6–11.8). Resultado inmediato y visual.</p>
+
+  <div class="grid">
+    <!-- Controles -->
+    <div class="card">
+      <div class="row">
+        <div>
+          <label>Sistema / fluido de la tubería</label>
+          <select id="system"></select>
+        </div>
+        <div>
+          <label>Ubicación (espacio o tanque)</label>
+          <select id="location"></select>
+        </div>
+      </div>
+
+      <div class="row" style="margin-top:10px">
+        <div>
+          <label>Material</label>
+          <select id="material">
+            <option value="steel">Steel (Tabla 11.6)</option>
+            <option value="stainless">Austenitic stainless steel (Tabla 11.7)</option>
+            <option value="copper">Copper (Tabla 11.8)</option>
+            <option value="copper_alloy">Copper alloys (Tabla 11.8)</option>
+          </select>
+          <div id="groupBox" class="hint">Grupo (solo steel): <b id="groupHint">—</b></div>
+        </div>
+        <div>
+          <label>Diámetro exterior d<sub>a</sub> [mm]</label>
+          <input id="da" type="number" step="0.1" min="1" value="60"/>
+          <div class="hint">El espesor s se calcula según el intervalo [mín, máx] en la tabla del material.</div>
+        </div>
+      </div>
+
+      <div style="margin-top:10px;display:flex;align-items:center;gap:6px;flex-wrap:wrap">
+        <label style="display:flex;align-items:center;gap:6px;font-size:12px;color:#334155">
+          <input type="checkbox" id="allowDash"/> Permitir casos “–” (acuerdo especial) <span class="badge">avanzado</span>
+        </label>
+      </div>
+
+      <details style="margin-top:10px">
+        <summary><strong>Autoverificación de lógica (tests unitarios)</strong></summary>
+        <div id="tests" class="tests"></div>
+      </details>
+    </div>
+
+    <!-- Vista / resultado -->
+    <div class="card result">
+      <div class="svgbox" id="viz"></div>
+      <div class="legend">
+        <span class="pill ok">Compatible</span>
+        <span class="pill bad">No compatible</span>
+        <span class="pill warn">Especial (–)</span>
+        <span class="badge">Visual: tanque + tubo</span>
+      </div>
+      <div style="margin-top:10px">
+        <h2 id="headline">—</h2>
+        <div id="explain" class="small">—</div>
+      </div>
+
+      <table class="tbl" id="outTbl" style="display:none">
+        <thead>
+          <tr><th>Parámetro</th><th>Valor</th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </div>
+
+  <footer>
+    <p><strong>Leyenda</strong>: N/M/D = grupo para steel (espesor por Tabla 11.6). X = no instalar. “–” = solo con acuerdo especial de la Sociedad de Clasificación (por defecto tratado como no permitido).</p>
+  </footer>
+</div>
+
+<script>
+// ==============================
+// MATRIZ NORMATIVA (todas las ubicaciones) – valores: 'N','M','D','X','-'
+// ==============================
+const SPACES = [
+  'Machinery spaces','Cofferdams / void spaces','Cargo holds','Ballast water tanks',
+  'Fuel and changeover tanks','Fresh cooling water tanks','Lubricating oil tanks','Hydraulic oil tanks',
+  'Drinking water tanks','Thermal oil tanks','Condensate and feedwater tanks','Accommodation',
+  'Cargo tanks, tank ships','Cofferdams, tank ships','Cargo pump rooms','Weather deck',
+];
+
+const SYSTEMS = [
+  'Bilge lines','Ballast lines','Seawater lines','Fuel lines','Lubricating lines',
+  'Thermal oil lines','Steam lines','Condensate lines','Feedwater lines',
+  'Drinking water lines','Fresh cooling water lines','Compressed air lines','Hydraulic lines'
+];
+
+const MATRIX = {
+  'Bilge lines': {
+    'Machinery spaces':'M','Cofferdams / void spaces':'M','Cargo holds':'M','Ballast water tanks':'D','Fuel and changeover tanks':'D','Fresh cooling water tanks':'X','Lubricating oil tanks':'X','Hydraulic oil tanks':'X','Drinking water tanks':'X','Thermal oil tanks':'X','Condensate and feedwater tanks':'X','Accommodation':'X','Cargo tanks, tank ships':'X','Cofferdams, tank ships':'M','Cargo pump rooms':'M','Weather deck':'-'
+  },
+  'Ballast lines': {
+    'Machinery spaces':'M','Cofferdams / void spaces':'M','Cargo holds':'D','Ballast water tanks':'M','Fuel and changeover tanks':'D','Fresh cooling water tanks':'X','Lubricating oil tanks':'X','Hydraulic oil tanks':'X','Drinking water tanks':'X','Thermal oil tanks':'X','Condensate and feedwater tanks':'X','Accommodation':'M','Cargo tanks, tank ships':'-','Cofferdams, tank ships':'-','Cargo pump rooms':'M','Weather deck':'N'
+  },
+  'Seawater lines': {
+    'Machinery spaces':'M','Cofferdams / void spaces':'M','Cargo holds':'D','Ballast water tanks':'M','Fuel and changeover tanks':'D','Fresh cooling water tanks':'X','Lubricating oil tanks':'X','Hydraulic oil tanks':'X','Drinking water tanks':'X','Thermal oil tanks':'X','Condensate and feedwater tanks':'X','Accommodation':'X','Cargo tanks, tank ships':'X','Cofferdams, tank ships':'-','Cargo pump rooms':'M','Weather deck':'N'
+  },
+  'Fuel lines': {
+    'Machinery spaces':'N','Cofferdams / void spaces':'M','Cargo holds':'D','Ballast water tanks':'D','Fuel and changeover tanks':'N','Fresh cooling water tanks':'X','Lubricating oil tanks':'X','Hydraulic oil tanks':'X','Drinking water tanks':'X','Thermal oil tanks':'X','Condensate and feedwater tanks':'X','Accommodation':'X','Cargo tanks, tank ships':'X','Cofferdams, tank ships':'-','Cargo pump rooms':'-','Weather deck':'N'
+  },
+  'Lubricating lines': {
+    'Machinery spaces':'N','Cofferdams / void spaces':'M','Cargo holds':'-','Ballast water tanks':'X','Fuel and changeover tanks':'X','Fresh cooling water tanks':'X','Lubricating oil tanks':'N','Hydraulic oil tanks':'-','Drinking water tanks':'X','Thermal oil tanks':'X','Condensate and feedwater tanks':'X','Accommodation':'X','Cargo tanks, tank ships':'X','Cofferdams, tank ships':'-','Cargo pump rooms':'-','Weather deck':'N'
+  },
+  'Thermal oil lines': {
+    'Machinery spaces':'N','Cofferdams / void spaces':'M','Cargo holds':'M','Ballast water tanks':'M','Fuel and changeover tanks':'M','Fresh cooling water tanks':'M','Lubricating oil tanks':'M','Hydraulic oil tanks':'-','Drinking water tanks':'X','Thermal oil tanks':'N','Condensate and feedwater tanks':'X','Accommodation':'X','Cargo tanks, tank ships':'M','Cofferdams, tank ships':'-','Cargo pump rooms':'N','Weather deck':'N'
+  },
+  'Steam lines': {
+    'Machinery spaces':'N','Cofferdams / void spaces':'M','Cargo holds':'M','Ballast water tanks':'M','Fuel and changeover tanks':'M','Fresh cooling water tanks':'M','Lubricating oil tanks':'M','Hydraulic oil tanks':'-','Drinking water tanks':'X','Thermal oil tanks':'X','Condensate and feedwater tanks':'N','Accommodation':'N','Cargo tanks, tank ships':'M','Cofferdams, tank ships':'-','Cargo pump rooms':'N','Weather deck':'N'
+  },
+  'Condensate lines': {
+    'Machinery spaces':'N','Cofferdams / void spaces':'M','Cargo holds':'M','Ballast water tanks':'M','Fuel and changeover tanks':'M','Fresh cooling water tanks':'M','Lubricating oil tanks':'M','Hydraulic oil tanks':'-','Drinking water tanks':'X','Thermal oil tanks':'X','Condensate and feedwater tanks':'N','Accommodation':'N','Cargo tanks, tank ships':'M','Cofferdams, tank ships':'-','Cargo pump rooms':'N','Weather deck':'N'
+  },
+  'Feedwater lines': {
+    'Machinery spaces':'N','Cofferdams / void spaces':'M','Cargo holds':'M','Ballast water tanks':'X','Fuel and changeover tanks':'X','Fresh cooling water tanks':'X','Lubricating oil tanks':'X','Hydraulic oil tanks':'X','Drinking water tanks':'X','Thermal oil tanks':'X','Condensate and feedwater tanks':'N','Accommodation':'X','Cargo tanks, tank ships':'X','Cofferdams, tank ships':'X','Cargo pump rooms':'X','Weather deck':'N'
+  },
+  'Drinking water lines': {
+    'Machinery spaces':'N','Cofferdams / void spaces':'M','Cargo holds':'M','Ballast water tanks':'X','Fuel and changeover tanks':'X','Fresh cooling water tanks':'X','Lubricating oil tanks':'X','Hydraulic oil tanks':'X','Drinking water tanks':'N','Thermal oil tanks':'X','Condensate and feedwater tanks':'X','Accommodation':'N','Cargo tanks, tank ships':'X','Cofferdams, tank ships':'X','Cargo pump rooms':'X','Weather deck':'N'
+  },
+  'Fresh cooling water lines': {
+    'Machinery spaces':'N','Cofferdams / void spaces':'M','Cargo holds':'M','Ballast water tanks':'X','Fuel and changeover tanks':'D','Fresh cooling water tanks':'N','Lubricating oil tanks':'D','Hydraulic oil tanks':'X','Drinking water tanks':'X','Thermal oil tanks':'X','Condensate and feedwater tanks':'X','Accommodation':'X','Cargo tanks, tank ships':'X','Cofferdams, tank ships':'X','Cargo pump rooms':'-','Weather deck':'N'
+  },
+  'Compressed air lines': {
+    'Machinery spaces':'N','Cofferdams / void spaces':'M','Cargo holds':'M','Ballast water tanks':'M','Fuel and changeover tanks':'M','Fresh cooling water tanks':'M','Lubricating oil tanks':'M','Hydraulic oil tanks':'N','Drinking water tanks':'X','Thermal oil tanks':'N','Condensate and feedwater tanks':'X','Accommodation':'N','Cargo tanks, tank ships':'X','Cofferdams, tank ships':'X','Cargo pump rooms':'N','Weather deck':'N'
+  },
+  'Hydraulic lines': {
+    'Machinery spaces':'N','Cofferdams / void spaces':'M','Cargo holds':'M','Ballast water tanks':'M','Fuel and changeover tanks':'M','Fresh cooling water tanks':'X','Lubricating oil tanks':'X','Hydraulic oil tanks':'N','Drinking water tanks':'X','Thermal oil tanks':'X','Condensate and feedwater tanks':'X','Accommodation':'X','Cargo tanks, tank ships':'N','Cofferdams, tank ships':'N','Cargo pump rooms':'N','Weather deck':'N'
+  },
+};
+
+// ==============================
+// Tablas 11.6–11.8 como INTERVALOS [min,max]
+// ==============================
+const STEEL = {
+  'N': [[10.2,13.5,1.6],[13.5,20.0,1.8],[20.0,48.3,2.0],[48.3,70.0,2.3],[70.0,88.9,2.6],[88.9,114.3,2.9],[114.3,133.0,3.2],[133.0,152.4,3.6],[152.4,177.8,4.0],[177.8,244.5,4.5],[244.5,323.9,5.0],[323.9,Infinity,5.6]],
+  'M': [[21.3,38.0,3.2],[38.0,51.0,3.6],[51.0,76.1,4.0],[76.1,177.8,4.5],[177.8,193.7,5.0],[193.7,219.1,5.4],[219.1,244.5,5.9],[244.5,406.4,6.3],[406.4,660.4,6.3],[660.4,762.0,7.1],[762.0,863.6,8.0],[863.6,914.4,8.8],[914.4,Infinity,10.0]],
+  'D': [[38.0,88.9,6.3],[88.9,114.3,7.1],[114.3,152.4,8.0],[152.4,Infinity,8.8]]
+};
+const INOX = [[0,17.2,1.0],[17.2,48.3,1.6],[48.3,88.9,2.0],[88.9,168.3,2.3],[168.3,219.1,2.6],[219.1,273.0,2.9],[273.0,406.0,3.6],[406.0,Infinity,4.0]];
+const COPPER = [[8.0,10.0,1.0,0.8],[12.0,20.0,1.2,1.0],[25.0,44.5,1.5,1.2],[50.0,76.1,2.0,1.5],[88.9,108.0,2.5,2.0],[133.0,159.0,3.0,2.5],[193.7,267.0,3.5,3.0],[273.0,457.2,4.0,3.5],[470.0,508.0,4.5,4.0]];
+
+function inRangeClosedOpen(x,a,b){return x>=a && x<b;}
+function inRangeClosed(x,a,b){return x>=a && x<=b;}
+function tSteel(group,da){const arr=STEEL[group]||[];for(const[lo,hi,s]of arr){if(inRangeClosedOpen(da,lo,hi))return s;}return null;}
+function tInox(da){for(const[lo,hi,s]of INOX){if(inRangeClosedOpen(da,lo,hi))return s;}return null;}
+function tCopper(da,alloy){for(const[lo,hi,scu,sall]of COPPER){if(inRangeClosed(da,lo,hi))return alloy?sall:scu;}return null;}
+
+// ==============================
+// UI helpers
+// ==============================
+function fill(id,arr){const el=document.getElementById(id);el.innerHTML='';arr.forEach(v=>{const o=document.createElement('option');o.value=o.textContent=v;el.appendChild(o);});}
+
+function drawViz({status,place,system,s}){
+  const svg=document.getElementById('viz');
+  const w=svg.clientWidth,h=svg.clientHeight,pad=24;
+  const tankX=pad,tankY=pad,tankW=w-pad*2,tankH=h-pad*2;
+  const pipeY=tankY+tankH*0.55;
+  const color=status==='ok'?'var(--ok)':status==='warn'?'var(--warn)':'var(--bad)';
+  svg.innerHTML=`
+  <svg width="100%" height="100%" viewBox="0 0 ${w} ${h}" xmlns="http://www.w3.org/2000/svg">
+    <defs><linearGradient id="liq" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e0f2fe"/><stop offset="100%" stop-color="#bae6fd"/></linearGradient></defs>
+    <rect x="${tankX}" y="${tankY}" rx="18" ry="18" width="${tankW}" height="${tankH}" fill="url(#liq)" stroke="#0ea5e9" stroke-width="3"/>
+    <text x="${tankX+tankW/2}" y="${tankY+22}" text-anchor="middle" font-size="14" fill="#0f172a" font-weight="700">${place}</text>
+    <rect x="${tankX-40}" y="${pipeY-12}" width="${tankW+80}" height="24" rx="12" ry="12" fill="${color}" opacity="0.9"/>
+    <text x="${tankX+tankW/2}" y="${pipeY-20}" text-anchor="middle" font-size="13" fill="#0f172a">${system}</text>
+    ${status==='ok'&&s?`<text x="${tankX+tankW/2}" y="${pipeY+38}" text-anchor="middle" font-size="13" fill="#065f46">s = ${s.toFixed(1)} mm</text>`:''}
+    ${status==='bad'?`<line x1="${tankX+8}" y1="${tankY+8}" x2="${tankX+tankW-8}" y2="${tankY+tankH-8}" stroke="var(--bad)" stroke-width="6" opacity="0.8" /><line x1="${tankX+tankW-8}" y1="${tankY+8}" x2="${tankX+8}" y2="${tankY+tankH-8}" stroke="var(--bad)" stroke-width="6" opacity="0.8" />`:''}
+  </svg>`;
+}
+
+function calc(){
+  const system=document.getElementById('system').value;
+  const locationSel=document.getElementById('location').value;
+  const mat=document.getElementById('material').value;
+  const da=parseFloat(document.getElementById('da').value);
+  const allowDash=document.getElementById('allowDash').checked;
+
+  const cell=(MATRIX[system]||{})[locationSel];
+  let symbol=cell||'X';
+  let group=null;
+
+  if(symbol==='-' && !allowDash){
+    drawViz({status:'warn',place:locationSel,system});
+    document.getElementById('headline').innerHTML='<span class="pill warn">Especial (–)</span>';
+    document.getElementById('explain').innerHTML='Esta combinación requiere acuerdo especial de la Sociedad de Clasificación. Por defecto se trata como no permitida; marca la casilla “Permitir casos –” para forzar el cálculo bajo tu responsabilidad.';
+    document.getElementById('groupHint').textContent='—';
+    document.getElementById('outTbl').style.display='none';
+    return;
+  }
+
+  if(symbol==='X'){
+    drawViz({status:'bad',place:locationSel,system});
+    document.getElementById('headline').innerHTML='<span class="pill bad">No compatible</span>';
+    document.getElementById('explain').innerHTML='La tabla normativa (11.5) marca “X”: la tubería no debe instalarse en esta ubicación.';
+    document.getElementById('groupHint').textContent='—';
+    document.getElementById('outTbl').style.display='none';
+    return;
+  }
+
+  let s=null; let rule='';
+  if(mat==='steel'){
+    group=symbol;
+    document.getElementById('groupHint').textContent=group;
+    s=tSteel(group,da);
+    if(s==null){
+      drawViz({status:'bad',place:locationSel,system});
+      document.getElementById('headline').innerHTML='<span class="pill bad">Fuera de tabla (steel)</span>';
+      document.getElementById('explain').innerHTML='El diámetro ingresado no cae en ningún intervalo de la Tabla 11.6 para el grupo '+group+'. Ajusta dₐ o consulta a clase.';
+      document.getElementById('outTbl').style.display='none'; return;
+    }
+    rule=`Steel grupo <b>${group}</b> · Tabla 11.6 · intervalo válido para d<sub>a</sub> = ${da} mm.`;
+  } else if(mat==='stainless'){
+    document.getElementById('groupHint').textContent='—';
+    s=tInox(da);
+    if(s==null){
+      drawViz({status:'bad',place:locationSel,system});
+      document.getElementById('headline').innerHTML='<span class="pill bad">Fuera de tabla (inox)</span>';
+      document.getElementById('explain').innerHTML='El diámetro no cae en los intervalos de la Tabla 11.7.';
+      document.getElementById('outTbl').style.display='none'; return;
+    }
+    rule='Austenitic stainless steel · Tabla 11.7 · intervalo válido.';
+  } else {
+    document.getElementById('groupHint').textContent='—';
+    s=tCopper(da,mat==='copper_alloy');
+    if(s==null){
+      drawViz({status:'bad',place:locationSel,system});
+      document.getElementById('headline').innerHTML='<span class="pill bad">Fuera de tabla (cobre)</span>';
+      document.getElementById('explain').innerHTML='El diámetro no coincide con ningún rango de la Tabla 11.8 (tiene huecos entre tramos).';
+      document.getElementById('outTbl').style.display='none'; return;
+    }
+    rule=`${mat==='copper'?'Copper':'Copper alloy'} · Tabla 11.8 · rango válido.`;
+  }
+
+  drawViz({status:'ok',place:locationSel,system,s});
+  document.getElementById('headline').innerHTML='<span class="pill ok">Compatible</span>';
+  document.getElementById('explain').innerHTML=`Espesor mínimo <b>s = ${s.toFixed(1)} mm</b>. ${rule}`;
+
+  const tbody=document.querySelector('#outTbl tbody');
+  tbody.innerHTML='';
+  const rows=[
+    ['Sistema',system],['Ubicación',locationSel],['Material',document.getElementById('material').options[document.getElementById('material').selectedIndex].text],
+    ['Símbolo (Tabla 11.5)',symbol],['Grupo (si steel)',group||'—'],['dₐ [mm]',da],['Espesor s [mm]',s.toFixed(1)],
+  ];
+  for(const[k,v]of rows){const tr=document.createElement('tr');const a=document.createElement('td');a.textContent=k;tr.appendChild(a);const b=document.createElement('td');b.innerHTML=String(v);tr.appendChild(b);tbody.appendChild(tr);}
+  document.getElementById('outTbl').style.display='table';
+}
+
+function runTests(){
+  const cases=[];
+  cases.push(['Fuel lines en Fuel&changeover = N',MATRIX['Fuel lines']['Fuel and changeover tanks']==='N']);
+  cases.push(['Bilge lines en Ballast = D',MATRIX['Bilge lines']['Ballast water tanks']==='D']);
+  cases.push(['Fresh cooling line en Fresh cooling tank = N',MATRIX['Fresh cooling water lines']['Fresh cooling water tanks']==='N']);
+  cases.push(['Hydraulic lines en Hydraulic oil tank = N',MATRIX['Hydraulic lines']['Hydraulic oil tanks']==='N']);
+  cases.push(['Drinking water line en Drinking water tank = N',MATRIX['Drinking water lines']['Drinking water tanks']==='N']);
+  cases.push(['Fuel lines en Machinery spaces = N',MATRIX['Fuel lines']['Machinery spaces']==='N']);
+  cases.push(['Bilge en Cofferdams/void = M',MATRIX['Bilge lines']['Cofferdams / void spaces']==='M']);
+  cases.push(['Steam en Accommodation = N',MATRIX['Steam lines']['Accommodation']==='N']);
+  cases.push(['Compressed air en Thermal oil tanks = N',MATRIX['Compressed air lines']['Thermal oil tanks']==='N']);
+  cases.push(['Hydraulic lines en Cargo tanks (tank ships) = N',MATRIX['Hydraulic lines']['Cargo tanks, tank ships']==='N']);
+  cases.push(['Fresh cooling line en Cargo pump rooms = –',MATRIX['Fresh cooling water lines']['Cargo pump rooms']==='-']);
+  cases.push(['Steel M, dₐ=21.3 ⇒ s=3.2',Math.abs(tSteel('M',21.3)-3.2)<1e-9]);
+  cases.push(['Steel D, dₐ=160 ⇒ s=8.8',Math.abs(tSteel('D',160)-8.8)<1e-9]);
+  cases.push(['Inox, dₐ=21.3 ⇒ s=1.6',Math.abs(tInox(21.3)-1.6)<1e-9]);
+  cases.push(['Copper, dₐ=25 ⇒ s=1.5',Math.abs(tCopper(25,false)-1.5)<1e-9]);
+  cases.push(['Copper, dₐ=21 ⇒ fuera de tabla',tCopper(21,false)===null]);
+
+  const ok=cases.every(([_,p])=>p);
+  document.getElementById('tests').innerHTML=(ok?'✅ Lógica verificada':'❌ Falla en pruebas')+'<br>'+cases.map(([n,p])=>(p?'✔️ ':'❌ ')+n).join('<br>');
+}
+
+// INIT
+fill('system',SYSTEMS); fill('location',SPACES);
+['system','location','material','da','allowDash'].forEach(id=>{
+  document.getElementById(id).addEventListener('change',calc);
+  document.getElementById(id).addEventListener('input',calc);
+});
+runTests();
+calc();
+</script>
+</body>
+</html>
+

--- a/index.html
+++ b/index.html
@@ -3,320 +3,159 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Compatibilidad de tuberías a través de tanques · Norma cerrada</title>
+<title>Herramientas · Pasos a través de tanques y juntas</title>
 <style>
-  :root{--ok:#16a34a;--bad:#dc2626;--warn:#d97706;--ink:#0f172a;--mut:#64748b;--bg:#f8fafc;--card:#ffffff}
-  html,body{margin:0;background:var(--bg);color:var(--ink);font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,'Helvetica Neue',Arial,'Noto Sans',sans-serif}
-  .wrap{max-width:1200px;margin:auto;padding:22px}
-  h1{font-size:22px;margin:0 0 8px}
-  .grid{display:grid;grid-template-columns:1.15fr 1fr;gap:18px}
-  .card{background:var(--card);border-radius:16px;box-shadow:0 10px 25px rgba(2,8,23,.06);padding:16px}
-  .row{display:grid;grid-template-columns:1fr 1fr;gap:10px}
-  label{font-size:12px;font-weight:700;color:#334155;display:block;margin-bottom:6px}
-  select,input{width:100%;padding:10px 12px;border:1px solid #e2e8f0;border-radius:10px;background:#fff;font-size:14px}
-  .hint{font-size:12px;color:var(--mut);margin-top:6px}
-  .pill{display:inline-flex;align-items:center;gap:6px;border-radius:999px;padding:6px 10px;font-weight:700;font-size:12px}
-  .pill.ok{background:#dcfce7;color:#065f46}
-  .pill.bad{background:#fee2e2;color:#991b1b}
-  .pill.warn{background:#fef3c7;color:#92400e}
-  .mono{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,'Liberation Mono',monospace}
-  .svgbox{position:relative;width:100%;aspect-ratio: 4/3;background:linear-gradient(180deg,#f1f5f9, #eef2ff)}
-  .legend{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px}
-  .tbl{width:100%;border-collapse:collapse;font-size:13px;margin-top:10px}
-  .tbl th,.tbl td{border:1px solid #e2e8f0;padding:8px}
-  .tbl th{background:#f1f5f9;text-align:left}
-  .small{font-size:12px;color:#475569}
-  .badge{display:inline-block;background:#eef2ff;color:#3730a3;border:1px solid #c7d2fe;padding:3px 6px;border-radius:999px;font-size:11px}
-  footer{margin-top:18px;font-size:12px;color:#475569}
-  .tests{font-size:12px;line-height:1.2}
-  .tests b{font-weight:800}
+  :root {
+    --bg: #0f172a;
+    --bg-soft: #1e293b;
+    --bg-card: rgba(15, 23, 42, 0.8);
+    --ink: #e2e8f0;
+    --accent: #38bdf8;
+    --accent-2: #a855f7;
+    --shadow: 0 20px 45px rgba(2, 6, 23, 0.5);
+  }
+  * { box-sizing: border-box; }
+  html, body {
+    margin: 0;
+    min-height: 100%;
+    background: radial-gradient(circle at top, #1e293b 0%, #0f172a 60%, #020617 100%);
+    color: var(--ink);
+    font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  }
+  a { color: inherit; }
+  .wrap {
+    max-width: 1080px;
+    margin: 0 auto;
+    padding: 48px 24px 64px;
+  }
+  header {
+    text-align: center;
+    margin-bottom: 48px;
+  }
+  h1 {
+    margin: 0 0 12px;
+    font-size: clamp(28px, 4vw, 40px);
+    letter-spacing: -0.01em;
+  }
+  .intro {
+    font-size: 16px;
+    line-height: 1.6;
+    max-width: 720px;
+    margin: 0 auto;
+    color: rgba(226, 232, 240, 0.78);
+  }
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 28px;
+  }
+  .card {
+    background: var(--bg-card);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    border-radius: 26px;
+    padding: 28px;
+    position: relative;
+    overflow: hidden;
+    box-shadow: var(--shadow);
+    display: flex;
+    flex-direction: column;
+    backdrop-filter: blur(12px);
+  }
+  .card h2 {
+    margin: 0 0 12px;
+    font-size: 22px;
+  }
+  .card p {
+    margin: 0 0 20px;
+    font-size: 15px;
+    line-height: 1.6;
+    color: rgba(226, 232, 240, 0.76);
+  }
+  .meta {
+    font-size: 13px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: rgba(148, 163, 184, 0.8);
+    margin-bottom: 16px;
+  }
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding: 12px 18px;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    font-weight: 600;
+    font-size: 15px;
+    text-decoration: none;
+    margin-top: auto;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+  }
+  .btn span {
+    font-size: 18px;
+  }
+  .btn.primary {
+    background: linear-gradient(135deg, var(--accent), #0ea5e9);
+    color: #0b1120;
+    box-shadow: 0 12px 30px rgba(14, 165, 233, 0.35);
+  }
+  .btn.secondary {
+    background: linear-gradient(135deg, var(--accent-2), #ec4899);
+    color: #0b1120;
+    box-shadow: 0 12px 30px rgba(168, 85, 247, 0.35);
+  }
+  .btn:hover {
+    transform: translateY(-3px);
+  }
+  footer {
+    margin-top: 56px;
+    text-align: center;
+    font-size: 13px;
+    color: rgba(148, 163, 184, 0.7);
+  }
+  footer a {
+    color: var(--accent);
+    text-decoration: none;
+  }
 </style>
 </head>
 <body>
-<div class="wrap">
-  <h1>¿Puede pasar una <em>tubería</em> a través de una <em>ubicación</em>?</h1>
-  <p class="small">Norma referencia GL (Tabla 11.5) y espesores mínimos por material (Tablas 11.6–11.8). Resultado inmediato y visual.</p>
+  <div class="wrap">
+    <header>
+      <h1>Herramientas normativas para sistemas de tuberías</h1>
+      <p class="intro">
+        Accede a los asistentes interactivos desarrollados para comprobar requisitos reglamentarios en buques. Elige la función que necesitas: compatibilidad de tuberías que atraviesan tanques y espacios, o el nuevo asesor para juntas flexibles tipo Grip (Slip-on) según LR Naval Ships v0.7.
+      </p>
+    </header>
 
-  <div class="grid">
-    <!-- Controles -->
-    <div class="card">
-      <div class="row">
-        <div>
-          <label>Sistema / fluido de la tubería</label>
-          <select id="system"></select>
-        </div>
-        <div>
-          <label>Ubicación (espacio o tanque)</label>
-          <select id="location"></select>
-        </div>
-      </div>
+    <main class="grid">
+      <article class="card">
+        <div class="meta">GL · Tabla 11.5</div>
+        <h2>Compatibilidad de tuberías a través de tanques</h2>
+        <p>
+          Evalúa si una línea puede atravesar un tanque o espacio específico según las tablas 11.5–11.8. Incluye cálculo de espesor mínimo por material y representación visual inmediata.
+        </p>
+        <a class="btn primary" href="compatibilidad.html">
+          <span>→</span> Abrir herramienta
+        </a>
+      </article>
 
-      <div class="row" style="margin-top:10px">
-        <div>
-          <label>Material</label>
-          <select id="material">
-            <option value="steel">Steel (Tabla 11.6)</option>
-            <option value="stainless">Austenitic stainless steel (Tabla 11.7)</option>
-            <option value="copper">Copper (Tabla 11.8)</option>
-            <option value="copper_alloy">Copper alloys (Tabla 11.8)</option>
-          </select>
-          <div id="groupBox" class="hint">Grupo (solo steel): <b id="groupHint">—</b></div>
-        </div>
-        <div>
-          <label>Diámetro exterior d<sub>a</sub> [mm]</label>
-          <input id="da" type="number" step="0.1" min="1" value="60"/>
-          <div class="hint">El espesor s se calcula según el intervalo [mín, máx] en la tabla del material.</div>
-        </div>
-      </div>
+      <article class="card">
+        <div class="meta">LR Naval Ships · Tabla 1.5</div>
+        <h2>Asesor Grip-Type para juntas Slip-on</h2>
+        <p>
+          Determina la viabilidad de juntas mecánicas Slip-on, Pipe Unions y Compression por sistema, clase y ubicación. Incluye notas normativas traducidas y visor ligero de esquemas SVG.
+        </p>
+        <a class="btn secondary" href="asesor-grip-type.html">
+          <span>→</span> Explorar asesor
+        </a>
+      </article>
+    </main>
 
-      <div style="margin-top:10px;display:flex;align-items:center;gap:6px;flex-wrap:wrap">
-        <label style="display:flex;align-items:center;gap:6px;font-size:12px;color:#334155">
-          <input type="checkbox" id="allowDash"/> Permitir casos “–” (acuerdo especial) <span class="badge">avanzado</span>
-        </label>
-      </div>
-
-      <details style="margin-top:10px">
-        <summary><strong>Autoverificación de lógica (tests unitarios)</strong></summary>
-        <div id="tests" class="tests"></div>
-      </details>
-    </div>
-
-    <!-- Vista / resultado -->
-    <div class="card result">
-      <div class="svgbox" id="viz"></div>
-      <div class="legend">
-        <span class="pill ok">Compatible</span>
-        <span class="pill bad">No compatible</span>
-        <span class="pill warn">Especial (–)</span>
-        <span class="badge">Visual: tanque + tubo</span>
-      </div>
-      <div style="margin-top:10px">
-        <h2 id="headline">—</h2>
-        <div id="explain" class="small">—</div>
-      </div>
-
-      <table class="tbl" id="outTbl" style="display:none">
-        <thead>
-          <tr><th>Parámetro</th><th>Valor</th></tr>
-        </thead>
-        <tbody></tbody>
-      </table>
-    </div>
+    <footer>
+      <p>¿Necesitas otra integración? Escríbenos y la añadimos en esta misma plataforma.</p>
+    </footer>
   </div>
-
-  <footer>
-    <p><strong>Leyenda</strong>: N/M/D = grupo para steel (espesor por Tabla 11.6). X = no instalar. “–” = solo con acuerdo especial de la Sociedad de Clasificación (por defecto tratado como no permitido).</p>
-  </footer>
-</div>
-
-<script>
-// ==============================
-// MATRIZ NORMATIVA (todas las ubicaciones) – valores: 'N','M','D','X','-'
-// ==============================
-const SPACES = [
-  'Machinery spaces','Cofferdams / void spaces','Cargo holds','Ballast water tanks',
-  'Fuel and changeover tanks','Fresh cooling water tanks','Lubricating oil tanks','Hydraulic oil tanks',
-  'Drinking water tanks','Thermal oil tanks','Condensate and feedwater tanks','Accommodation',
-  'Cargo tanks, tank ships','Cofferdams, tank ships','Cargo pump rooms','Weather deck',
-];
-
-const SYSTEMS = [
-  'Bilge lines','Ballast lines','Seawater lines','Fuel lines','Lubricating lines',
-  'Thermal oil lines','Steam lines','Condensate lines','Feedwater lines',
-  'Drinking water lines','Fresh cooling water lines','Compressed air lines','Hydraulic lines'
-];
-
-const MATRIX = {
-  'Bilge lines': {
-    'Machinery spaces':'M','Cofferdams / void spaces':'M','Cargo holds':'M','Ballast water tanks':'D','Fuel and changeover tanks':'D','Fresh cooling water tanks':'X','Lubricating oil tanks':'X','Hydraulic oil tanks':'X','Drinking water tanks':'X','Thermal oil tanks':'X','Condensate and feedwater tanks':'X','Accommodation':'X','Cargo tanks, tank ships':'X','Cofferdams, tank ships':'M','Cargo pump rooms':'M','Weather deck':'-'
-  },
-  'Ballast lines': {
-    'Machinery spaces':'M','Cofferdams / void spaces':'M','Cargo holds':'D','Ballast water tanks':'M','Fuel and changeover tanks':'D','Fresh cooling water tanks':'X','Lubricating oil tanks':'X','Hydraulic oil tanks':'X','Drinking water tanks':'X','Thermal oil tanks':'X','Condensate and feedwater tanks':'X','Accommodation':'M','Cargo tanks, tank ships':'-','Cofferdams, tank ships':'-','Cargo pump rooms':'M','Weather deck':'N'
-  },
-  'Seawater lines': {
-    'Machinery spaces':'M','Cofferdams / void spaces':'M','Cargo holds':'D','Ballast water tanks':'M','Fuel and changeover tanks':'D','Fresh cooling water tanks':'X','Lubricating oil tanks':'X','Hydraulic oil tanks':'X','Drinking water tanks':'X','Thermal oil tanks':'X','Condensate and feedwater tanks':'X','Accommodation':'X','Cargo tanks, tank ships':'X','Cofferdams, tank ships':'-','Cargo pump rooms':'M','Weather deck':'N'
-  },
-  'Fuel lines': {
-    'Machinery spaces':'N','Cofferdams / void spaces':'M','Cargo holds':'D','Ballast water tanks':'D','Fuel and changeover tanks':'N','Fresh cooling water tanks':'X','Lubricating oil tanks':'X','Hydraulic oil tanks':'X','Drinking water tanks':'X','Thermal oil tanks':'X','Condensate and feedwater tanks':'X','Accommodation':'X','Cargo tanks, tank ships':'X','Cofferdams, tank ships':'-','Cargo pump rooms':'-','Weather deck':'N'
-  },
-  'Lubricating lines': {
-    'Machinery spaces':'N','Cofferdams / void spaces':'M','Cargo holds':'-','Ballast water tanks':'X','Fuel and changeover tanks':'X','Fresh cooling water tanks':'X','Lubricating oil tanks':'N','Hydraulic oil tanks':'-','Drinking water tanks':'X','Thermal oil tanks':'X','Condensate and feedwater tanks':'X','Accommodation':'X','Cargo tanks, tank ships':'X','Cofferdams, tank ships':'-','Cargo pump rooms':'-','Weather deck':'N'
-  },
-  'Thermal oil lines': {
-    'Machinery spaces':'N','Cofferdams / void spaces':'M','Cargo holds':'M','Ballast water tanks':'M','Fuel and changeover tanks':'M','Fresh cooling water tanks':'M','Lubricating oil tanks':'M','Hydraulic oil tanks':'-','Drinking water tanks':'X','Thermal oil tanks':'N','Condensate and feedwater tanks':'X','Accommodation':'X','Cargo tanks, tank ships':'M','Cofferdams, tank ships':'-','Cargo pump rooms':'N','Weather deck':'N'
-  },
-  'Steam lines': {
-    'Machinery spaces':'N','Cofferdams / void spaces':'M','Cargo holds':'M','Ballast water tanks':'M','Fuel and changeover tanks':'M','Fresh cooling water tanks':'M','Lubricating oil tanks':'M','Hydraulic oil tanks':'-','Drinking water tanks':'X','Thermal oil tanks':'X','Condensate and feedwater tanks':'N','Accommodation':'N','Cargo tanks, tank ships':'M','Cofferdams, tank ships':'-','Cargo pump rooms':'N','Weather deck':'N'
-  },
-  'Condensate lines': {
-    'Machinery spaces':'N','Cofferdams / void spaces':'M','Cargo holds':'M','Ballast water tanks':'M','Fuel and changeover tanks':'M','Fresh cooling water tanks':'M','Lubricating oil tanks':'M','Hydraulic oil tanks':'-','Drinking water tanks':'X','Thermal oil tanks':'X','Condensate and feedwater tanks':'N','Accommodation':'N','Cargo tanks, tank ships':'M','Cofferdams, tank ships':'-','Cargo pump rooms':'N','Weather deck':'N'
-  },
-  'Feedwater lines': {
-    'Machinery spaces':'N','Cofferdams / void spaces':'M','Cargo holds':'M','Ballast water tanks':'X','Fuel and changeover tanks':'X','Fresh cooling water tanks':'X','Lubricating oil tanks':'X','Hydraulic oil tanks':'X','Drinking water tanks':'X','Thermal oil tanks':'X','Condensate and feedwater tanks':'N','Accommodation':'X','Cargo tanks, tank ships':'X','Cofferdams, tank ships':'X','Cargo pump rooms':'X','Weather deck':'N'
-  },
-  'Drinking water lines': {
-    'Machinery spaces':'N','Cofferdams / void spaces':'M','Cargo holds':'M','Ballast water tanks':'X','Fuel and changeover tanks':'X','Fresh cooling water tanks':'X','Lubricating oil tanks':'X','Hydraulic oil tanks':'X','Drinking water tanks':'N','Thermal oil tanks':'X','Condensate and feedwater tanks':'X','Accommodation':'N','Cargo tanks, tank ships':'X','Cofferdams, tank ships':'X','Cargo pump rooms':'X','Weather deck':'N'
-  },
-  'Fresh cooling water lines': {
-    'Machinery spaces':'N','Cofferdams / void spaces':'M','Cargo holds':'M','Ballast water tanks':'X','Fuel and changeover tanks':'D','Fresh cooling water tanks':'N','Lubricating oil tanks':'D','Hydraulic oil tanks':'X','Drinking water tanks':'X','Thermal oil tanks':'X','Condensate and feedwater tanks':'X','Accommodation':'X','Cargo tanks, tank ships':'X','Cofferdams, tank ships':'X','Cargo pump rooms':'-','Weather deck':'N'
-  },
-  'Compressed air lines': {
-    'Machinery spaces':'N','Cofferdams / void spaces':'M','Cargo holds':'M','Ballast water tanks':'M','Fuel and changeover tanks':'M','Fresh cooling water tanks':'M','Lubricating oil tanks':'M','Hydraulic oil tanks':'N','Drinking water tanks':'X','Thermal oil tanks':'N','Condensate and feedwater tanks':'X','Accommodation':'N','Cargo tanks, tank ships':'X','Cofferdams, tank ships':'X','Cargo pump rooms':'N','Weather deck':'N'
-  },
-  'Hydraulic lines': {
-    'Machinery spaces':'N','Cofferdams / void spaces':'M','Cargo holds':'M','Ballast water tanks':'M','Fuel and changeover tanks':'M','Fresh cooling water tanks':'X','Lubricating oil tanks':'X','Hydraulic oil tanks':'N','Drinking water tanks':'X','Thermal oil tanks':'X','Condensate and feedwater tanks':'X','Accommodation':'X','Cargo tanks, tank ships':'N','Cofferdams, tank ships':'N','Cargo pump rooms':'N','Weather deck':'N'
-  },
-};
-
-// ==============================
-// Tablas 11.6–11.8 como INTERVALOS [min,max]
-// ==============================
-const STEEL = {
-  'N': [[10.2,13.5,1.6],[13.5,20.0,1.8],[20.0,48.3,2.0],[48.3,70.0,2.3],[70.0,88.9,2.6],[88.9,114.3,2.9],[114.3,133.0,3.2],[133.0,152.4,3.6],[152.4,177.8,4.0],[177.8,244.5,4.5],[244.5,323.9,5.0],[323.9,Infinity,5.6]],
-  'M': [[21.3,38.0,3.2],[38.0,51.0,3.6],[51.0,76.1,4.0],[76.1,177.8,4.5],[177.8,193.7,5.0],[193.7,219.1,5.4],[219.1,244.5,5.9],[244.5,406.4,6.3],[406.4,660.4,6.3],[660.4,762.0,7.1],[762.0,863.6,8.0],[863.6,914.4,8.8],[914.4,Infinity,10.0]],
-  'D': [[38.0,88.9,6.3],[88.9,114.3,7.1],[114.3,152.4,8.0],[152.4,Infinity,8.8]]
-};
-const INOX = [[0,17.2,1.0],[17.2,48.3,1.6],[48.3,88.9,2.0],[88.9,168.3,2.3],[168.3,219.1,2.6],[219.1,273.0,2.9],[273.0,406.0,3.6],[406.0,Infinity,4.0]];
-const COPPER = [[8.0,10.0,1.0,0.8],[12.0,20.0,1.2,1.0],[25.0,44.5,1.5,1.2],[50.0,76.1,2.0,1.5],[88.9,108.0,2.5,2.0],[133.0,159.0,3.0,2.5],[193.7,267.0,3.5,3.0],[273.0,457.2,4.0,3.5],[470.0,508.0,4.5,4.0]];
-
-function inRangeClosedOpen(x,a,b){return x>=a && x<b;}
-function inRangeClosed(x,a,b){return x>=a && x<=b;}
-function tSteel(group,da){const arr=STEEL[group]||[];for(const[lo,hi,s]of arr){if(inRangeClosedOpen(da,lo,hi))return s;}return null;}
-function tInox(da){for(const[lo,hi,s]of INOX){if(inRangeClosedOpen(da,lo,hi))return s;}return null;}
-function tCopper(da,alloy){for(const[lo,hi,scu,sall]of COPPER){if(inRangeClosed(da,lo,hi))return alloy?sall:scu;}return null;}
-
-// ==============================
-// UI helpers
-// ==============================
-function fill(id,arr){const el=document.getElementById(id);el.innerHTML='';arr.forEach(v=>{const o=document.createElement('option');o.value=o.textContent=v;el.appendChild(o);});}
-
-function drawViz({status,place,system,s}){
-  const svg=document.getElementById('viz');
-  const w=svg.clientWidth,h=svg.clientHeight,pad=24;
-  const tankX=pad,tankY=pad,tankW=w-pad*2,tankH=h-pad*2;
-  const pipeY=tankY+tankH*0.55;
-  const color=status==='ok'?'var(--ok)':status==='warn'?'var(--warn)':'var(--bad)';
-  svg.innerHTML=`
-  <svg width="100%" height="100%" viewBox="0 0 ${w} ${h}" xmlns="http://www.w3.org/2000/svg">
-    <defs><linearGradient id="liq" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e0f2fe"/><stop offset="100%" stop-color="#bae6fd"/></linearGradient></defs>
-    <rect x="${tankX}" y="${tankY}" rx="18" ry="18" width="${tankW}" height="${tankH}" fill="url(#liq)" stroke="#0ea5e9" stroke-width="3"/>
-    <text x="${tankX+tankW/2}" y="${tankY+22}" text-anchor="middle" font-size="14" fill="#0f172a" font-weight="700">${place}</text>
-    <rect x="${tankX-40}" y="${pipeY-12}" width="${tankW+80}" height="24" rx="12" ry="12" fill="${color}" opacity="0.9"/>
-    <text x="${tankX+tankW/2}" y="${pipeY-20}" text-anchor="middle" font-size="13" fill="#0f172a">${system}</text>
-    ${status==='ok'&&s?`<text x="${tankX+tankW/2}" y="${pipeY+38}" text-anchor="middle" font-size="13" fill="#065f46">s = ${s.toFixed(1)} mm</text>`:''}
-    ${status==='bad'?`<line x1="${tankX+8}" y1="${tankY+8}" x2="${tankX+tankW-8}" y2="${tankY+tankH-8}" stroke="var(--bad)" stroke-width="6" opacity="0.8" /><line x1="${tankX+tankW-8}" y1="${tankY+8}" x2="${tankX+8}" y2="${tankY+tankH-8}" stroke="var(--bad)" stroke-width="6" opacity="0.8" />`:''}
-  </svg>`;
-}
-
-function calc(){
-  const system=document.getElementById('system').value;
-  const locationSel=document.getElementById('location').value;
-  const mat=document.getElementById('material').value;
-  const da=parseFloat(document.getElementById('da').value);
-  const allowDash=document.getElementById('allowDash').checked;
-
-  const cell=(MATRIX[system]||{})[locationSel];
-  let symbol=cell||'X';
-  let group=null;
-
-  if(symbol==='-' && !allowDash){
-    drawViz({status:'warn',place:locationSel,system});
-    document.getElementById('headline').innerHTML='<span class="pill warn">Especial (–)</span>';
-    document.getElementById('explain').innerHTML='Esta combinación requiere acuerdo especial de la Sociedad de Clasificación. Por defecto se trata como no permitida; marca la casilla “Permitir casos –” para forzar el cálculo bajo tu responsabilidad.';
-    document.getElementById('groupHint').textContent='—';
-    document.getElementById('outTbl').style.display='none';
-    return;
-  }
-
-  if(symbol==='X'){
-    drawViz({status:'bad',place:locationSel,system});
-    document.getElementById('headline').innerHTML='<span class="pill bad">No compatible</span>';
-    document.getElementById('explain').innerHTML='La tabla normativa (11.5) marca “X”: la tubería no debe instalarse en esta ubicación.';
-    document.getElementById('groupHint').textContent='—';
-    document.getElementById('outTbl').style.display='none';
-    return;
-  }
-
-  let s=null; let rule='';
-  if(mat==='steel'){
-    group=symbol;
-    document.getElementById('groupHint').textContent=group;
-    s=tSteel(group,da);
-    if(s==null){
-      drawViz({status:'bad',place:locationSel,system});
-      document.getElementById('headline').innerHTML='<span class="pill bad">Fuera de tabla (steel)</span>';
-      document.getElementById('explain').innerHTML='El diámetro ingresado no cae en ningún intervalo de la Tabla 11.6 para el grupo '+group+'. Ajusta dₐ o consulta a clase.';
-      document.getElementById('outTbl').style.display='none'; return;
-    }
-    rule=`Steel grupo <b>${group}</b> · Tabla 11.6 · intervalo válido para d<sub>a</sub> = ${da} mm.`;
-  } else if(mat==='stainless'){
-    document.getElementById('groupHint').textContent='—';
-    s=tInox(da);
-    if(s==null){
-      drawViz({status:'bad',place:locationSel,system});
-      document.getElementById('headline').innerHTML='<span class="pill bad">Fuera de tabla (inox)</span>';
-      document.getElementById('explain').innerHTML='El diámetro no cae en los intervalos de la Tabla 11.7.';
-      document.getElementById('outTbl').style.display='none'; return;
-    }
-    rule='Austenitic stainless steel · Tabla 11.7 · intervalo válido.';
-  } else {
-    document.getElementById('groupHint').textContent='—';
-    s=tCopper(da,mat==='copper_alloy');
-    if(s==null){
-      drawViz({status:'bad',place:locationSel,system});
-      document.getElementById('headline').innerHTML='<span class="pill bad">Fuera de tabla (cobre)</span>';
-      document.getElementById('explain').innerHTML='El diámetro no coincide con ningún rango de la Tabla 11.8 (tiene huecos entre tramos).';
-      document.getElementById('outTbl').style.display='none'; return;
-    }
-    rule=`${mat==='copper'?'Copper':'Copper alloy'} · Tabla 11.8 · rango válido.`;
-  }
-
-  drawViz({status:'ok',place:locationSel,system,s});
-  document.getElementById('headline').innerHTML='<span class="pill ok">Compatible</span>';
-  document.getElementById('explain').innerHTML=`Espesor mínimo <b>s = ${s.toFixed(1)} mm</b>. ${rule}`;
-
-  const tbody=document.querySelector('#outTbl tbody');
-  tbody.innerHTML='';
-  const rows=[
-    ['Sistema',system],['Ubicación',locationSel],['Material',document.getElementById('material').options[document.getElementById('material').selectedIndex].text],
-    ['Símbolo (Tabla 11.5)',symbol],['Grupo (si steel)',group||'—'],['dₐ [mm]',da],['Espesor s [mm]',s.toFixed(1)],
-  ];
-  for(const[k,v]of rows){const tr=document.createElement('tr');const a=document.createElement('td');a.textContent=k;tr.appendChild(a);const b=document.createElement('td');b.innerHTML=String(v);tr.appendChild(b);tbody.appendChild(tr);}
-  document.getElementById('outTbl').style.display='table';
-}
-
-function runTests(){
-  const cases=[];
-  cases.push(['Fuel lines en Fuel&changeover = N',MATRIX['Fuel lines']['Fuel and changeover tanks']==='N']);
-  cases.push(['Bilge lines en Ballast = D',MATRIX['Bilge lines']['Ballast water tanks']==='D']);
-  cases.push(['Fresh cooling line en Fresh cooling tank = N',MATRIX['Fresh cooling water lines']['Fresh cooling water tanks']==='N']);
-  cases.push(['Hydraulic lines en Hydraulic oil tank = N',MATRIX['Hydraulic lines']['Hydraulic oil tanks']==='N']);
-  cases.push(['Drinking water line en Drinking water tank = N',MATRIX['Drinking water lines']['Drinking water tanks']==='N']);
-  cases.push(['Fuel lines en Machinery spaces = N',MATRIX['Fuel lines']['Machinery spaces']==='N']);
-  cases.push(['Bilge en Cofferdams/void = M',MATRIX['Bilge lines']['Cofferdams / void spaces']==='M']);
-  cases.push(['Steam en Accommodation = N',MATRIX['Steam lines']['Accommodation']==='N']);
-  cases.push(['Compressed air en Thermal oil tanks = N',MATRIX['Compressed air lines']['Thermal oil tanks']==='N']);
-  cases.push(['Hydraulic lines en Cargo tanks (tank ships) = N',MATRIX['Hydraulic lines']['Cargo tanks, tank ships']==='N']);
-  cases.push(['Fresh cooling line en Cargo pump rooms = –',MATRIX['Fresh cooling water lines']['Cargo pump rooms']==='-']);
-  cases.push(['Steel M, dₐ=21.3 ⇒ s=3.2',Math.abs(tSteel('M',21.3)-3.2)<1e-9]);
-  cases.push(['Steel D, dₐ=160 ⇒ s=8.8',Math.abs(tSteel('D',160)-8.8)<1e-9]);
-  cases.push(['Inox, dₐ=21.3 ⇒ s=1.6',Math.abs(tInox(21.3)-1.6)<1e-9]);
-  cases.push(['Copper, dₐ=25 ⇒ s=1.5',Math.abs(tCopper(25,false)-1.5)<1e-9]);
-  cases.push(['Copper, dₐ=21 ⇒ fuera de tabla',tCopper(21,false)===null]);
-
-  const ok=cases.every(([_,p])=>p);
-  document.getElementById('tests').innerHTML=(ok?'✅ Lógica verificada':'❌ Falla en pruebas')+'<br>'+cases.map(([n,p])=>(p?'✔️ ':'❌ ')+n).join('<br>');
-}
-
-// INIT
-fill('system',SYSTEMS); fill('location',SPACES);
-['system','location','material','da','allowDash'].forEach(id=>{
-  document.getElementById(id).addEventListener('change',calc);
-  document.getElementById(id).addEventListener('input',calc);
-});
-runTests();
-calc();
-</script>
 </body>
 </html>
-


### PR DESCRIPTION
## Summary
- replace the single-page index with a landing page that links to each assistant
- move the existing compatibility calculator to compatibilidad.html with a back-to-home link
- add a new asesor-grip-type.html React page (via CDN) to run the Grip-Type Slip-on joint assessor with Tailwind styling

## Testing
- not run (static HTML project)


------
https://chatgpt.com/codex/tasks/task_e_68d1aa1b6e908321a1019627d491d6d6