### PR TITLE
Fix advisor loading and add no-babel build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Pasos de verificación
+
+1. Abrir `index.html` en el navegador. Desde la tarjeta del asesor, pulsar **Explorar asesor** y comprobar que `asesor-grip-type.html` se carga y muestra la interfaz.
+2. Con las DevTools abiertas, revisar la pestaña **Network** y confirmar que `asesor-grip-type.html` responde `200` al navegar desde la portada. Verificar en **Console** que no aparezcan errores (incluido CSP) ni mensajes de React indefinido.
+3. Probar ambas variantes directamente con rutas relativas:
+   - `./asesor-grip-type.html` (versión con Babel).
+   - `./asesor-grip-type-nobabel.html` (versión sin Babel, apta para CSP estricta).
+4. Si algún CDN estuviera bloqueado (ad blocker/empresa), deshabilitar el bloqueo y recargar.
+5. En despliegues bajo subrutas (por ejemplo GitHub Pages), mantener las rutas relativas (`./archivo.html`) para garantizar la navegación correcta.

--- a/asesor-grip-type-nobabel.html
+++ b/asesor-grip-type-nobabel.html
@@ -1,0 +1,569 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Asesor Grip-Type (Slip-on Joints) · LR Naval Ships</title>
+
+  <script>
+    tailwind = {
+      config: {
+        theme: {
+          extend: {
+            fontFamily: {
+              sans: ["Inter", "Segoe UI", "system-ui", "-apple-system", "sans-serif"],
+            },
+          },
+        },
+      },
+    };
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-slate-900 text-slate-100 min-h-screen">
+  <div class="p-4">
+    <a href="./index.html" class="inline-flex items-center gap-2 text-sm text-sky-300 hover:text-sky-100">
+      <span aria-hidden="true">←</span>
+      Volver al inicio
+    </a>
+  </div>
+  <div id="root"></div>
+
+  <script type="module">
+    import htm from 'https://unpkg.com/htm?module';
+    import { createElement as h, useState } from 'https://esm.sh/react@18';
+    import ReactDOM from 'https://esm.sh/react-dom@18/client';
+
+    const html = htm.bind(h);
+
+    const SearchIcon = ({ className = "w-4 h-4", ...props }) =>
+      h(
+        "svg",
+        {
+          className,
+          viewBox: "0 0 24 24",
+          fill: "none",
+          stroke: "currentColor",
+          strokeWidth: 2,
+          strokeLinecap: "round",
+          strokeLinejoin: "round",
+          ...props,
+        },
+        h("circle", { cx: 11, cy: 11, r: 7 }),
+        h("line", { x1: 21, y1: 21, x2: 16.65, y2: 16.65 })
+      );
+
+    const ShieldIcon = ({ className = "w-6 h-6", ...props }) =>
+      h(
+        "svg",
+        {
+          className,
+          viewBox: "0 0 24 24",
+          fill: "none",
+          stroke: "currentColor",
+          strokeWidth: 2,
+          strokeLinecap: "round",
+          strokeLinejoin: "round",
+          ...props,
+        },
+        h("path", { d: "M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" })
+      );
+
+    function App() {
+      const CLASS_LIMITS = {
+        steam: { classII: { P: 16, T: 300 }, classIII: { P: 7, T: 170 } },
+        thermal_oil: { classII: { P: 16, T: 300 }, classIII: { P: 7, T: 150 } },
+        flammable_liquids: { classII: { P: 16, T: 150 }, classIII: { P: 7, T: 60 } },
+        other_media: { classII: { P: 40, T: 300 }, classIII: { P: 16, T: 200 } },
+      };
+
+      const TABLE_NOTES_ES = {
+        "1": "Las juntas mecánicas que incluyan componentes que se deterioran fácilmente en caso de incendio deben ser de tipo resistente al fuego aprobado cuando se instalen en espacios de maquinaria de Categoría A. Los acoplamientos del ‘bilge main’ en espacios de Categoría A deben ser de acero, CuNi o material equivalente.",
+        "2": "Los slip‑on joints no se aceptan dentro de espacios de maquinaria de Categoría A, depósitos de munición ni espacios de alojamiento. Se aceptan en otros espacios de maquinaria y servicio siempre que queden en posiciones fácilmente visibles y accesibles.",
+        "3": "Las juntas mecánicas deben ser de tipo resistente al fuego aprobado, salvo cuando estén en cubiertas abiertas con poco o ningún riesgo de incendio según SOLAS II‑2/9.2.3.3.2.2(10).",
+        "4": "Las juntas mecánicas deben ser de tipo resistente al fuego aprobado.",
+        "5": "Ver Vol 2, Pt 7, Ch 1, 5.10 – Other mechanical couplings (remisión normativa).",
+        "6": "Las juntas mecánicas solo se permiten por encima del límite de integridad estanca (WTI).",
+        "7": "Requisitos para HVAC trunking y para entradas/salidas de turbina de gas se tratan en las secciones correspondientes de las Reglas.",
+      };
+
+      const NAVAL_SYSTEMS = [
+        { id: "ff_le60_aircraft_vehicle_fuel", group: "Flammable fluids (flash point ≤ 60°C)", system: "Aircraft and vehicle fuel oil lines", mediumGroup: "flammable_liquids", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "30 min dry (*)", notes: ["Notes 2 & 4"] },
+        { id: "ff_le60_vent_lines", group: "Flammable fluids (flash point ≤ 60°C)", system: "Vent lines", mediumGroup: "flammable_liquids", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "30 min dry (*)", notes: ["Notes 2 & 3"] },
+        { id: "ff_gt60_aircraft_vehicle_fuel", group: "Flammable fluids (flash point > 60°C)", system: "Aircraft and vehicle fuel oil lines", mediumGroup: "flammable_liquids", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "30 min dry (*)", notes: ["Notes 2 & 4"] },
+        { id: "ff_gt60_ship_machinery_fuel", group: "Flammable fluids (flash point > 60°C)", system: "Ship’s machinery fuel oil lines", mediumGroup: "flammable_liquids", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "30 min wet (*)", notes: ["Notes 2 & 3"] },
+        { id: "ff_gt60_lubricating_oil", group: "Flammable fluids (flash point > 60°C)", system: "Lubricating oil lines", mediumGroup: "flammable_liquids", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "30 min wet (*)", notes: ["Notes 2 & 3"] },
+        { id: "ff_gt60_hydraulic_oil", group: "Flammable fluids (flash point > 60°C)", system: "Hydraulic oil", mediumGroup: "flammable_liquids", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "30 min wet (*)", notes: ["Notes 2 & 3"] },
+        { id: "sw_bilge", group: "Sea water", system: "Bilge lines", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry/wet", fireTest: "8 min dry + 22 min wet (*)", notes: ["Note 1"] },
+        { id: "sw_hp_spray", group: "Sea water", system: "HP sea water and water spray (not permanently filled)", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry/wet", fireTest: "8 min dry + 22 min wet (*)" },
+        { id: "sw_perm_fireext", group: "Sea water", system: "Permanent water filled fire‑extinguishing systems (fire main, sprinklers)", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "30 min wet (*)", notes: ["Note 3"] },
+        { id: "sw_nonperm_fireext", group: "Sea water", system: "Non‑permanent water filled fire‑extinguishing systems (foam, drencher, fire main)", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry/wet", fireTest: "8 min dry + 22 min wet (*) – Foam: comply FSS Code", notes: ["Note 3"] },
+        { id: "sw_ballast", group: "Sea water", system: "Ballast system", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "8 min dry + 22 min wet (*)", notes: ["Note 1"] },
+        { id: "sw_cooling", group: "Sea water", system: "Cooling water system", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "8 min dry + 22 min wet (*)", notes: ["Note 1"] },
+        { id: "sw_tank_cleaning", group: "Sea water", system: "Tank cleaning services", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "Fire endurance test not required" },
+        { id: "sw_non_essential", group: "Sea water", system: "Non‑essential systems", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "Fire endurance test not required" },
+        { id: "fw_cooling", group: "Fresh water", system: "Cooling water system", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "Fire endurance test not required", notes: ["Note 1"] },
+        { id: "fw_chilled", group: "Fresh water", system: "Chilled water system", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "Except chilled water: 30 min wet (*)", notes: ["Note 1"] },
+        { id: "fw_condensate", group: "Fresh water", system: "Condensate return", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "Fire endurance test not required", notes: ["Note 1"] },
+        { id: "fw_whb", group: "Fresh water", system: "Water heating boiler", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "Fire endurance test not required", notes: ["Note 1"] },
+        { id: "fw_galley", group: "Fresh water", system: "Galley/cabin/domestic water", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "Fire endurance test not required" },
+        { id: "fw_sanitary", group: "Fresh water", system: "Sanitary water", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "Fire endurance test not required" },
+        { id: "fw_sprinkler", group: "Fresh water", system: "Sprinkler system", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "30 min wet (*)", notes: ["Note 3"] },
+        { id: "fw_hot_water_supply", group: "Fresh water", system: "Hot water supply", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "Fire endurance test not required" },
+        { id: "fw_nonessential", group: "Fresh water", system: "Non‑essential systems", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "Fire endurance test not required" },
+        { id: "thermal_heating", group: "Thermal oil", system: "Heating system", mediumGroup: "thermal_oil", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "30 min wet (*)", notes: ["Note 3"] },
+        { id: "thermal_other", group: "Thermal oil", system: "Other systems", mediumGroup: "thermal_oil", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "30 min wet (*)", notes: ["Note 3"] },
+        { id: "lube_wet", group: "Lubricating oil", system: "Wet system", mediumGroup: "flammable_liquids", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "30 min wet (*)", notes: ["Note 3"] },
+        { id: "lube_dry", group: "Lubricating oil", system: "Dry system", mediumGroup: "flammable_liquids", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "30 min dry (*)", notes: ["Note 3"] },
+        { id: "fuel_transfer", group: "Fuel oil", system: "Transfer system", mediumGroup: "flammable_liquids", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "30 min wet (*)", notes: ["Notes 2 & 3"] },
+        { id: "fuel_service", group: "Fuel oil", system: "Service system", mediumGroup: "flammable_liquids", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "30 min wet (*)", notes: ["Notes 2 & 3"] },
+        { id: "fuel_booster", group: "Fuel oil", system: "Booster/Injection system", mediumGroup: "flammable_liquids", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "30 min wet (*)", notes: ["Notes 2 & 3"] },
+        { id: "fuel_return", group: "Fuel oil", system: "Return system", mediumGroup: "flammable_liquids", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "30 min wet (*)", notes: ["Notes 2 & 3"] },
+        { id: "fuel_overflow", group: "Fuel oil", system: "Overflow", mediumGroup: "flammable_liquids", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "30 min wet (*)", notes: ["Notes 2 & 3"] },
+        { id: "fuel_vent", group: "Fuel oil", system: "Vent", mediumGroup: "flammable_liquids", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "30 min dry (*)", notes: ["Notes 2 & 3"] },
+        { id: "fuel_soundings", group: "Fuel oil", system: "Soundings", mediumGroup: "flammable_liquids", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "30 min dry (*)", notes: ["Notes 2 & 3"] },
+        { id: "misc_air_hp", group: "Miscellaneous", system: "High pressure (HP) air system", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "30 min dry (*)", notes: ["Note 1"] },
+        { id: "misc_air_mp", group: "Miscellaneous", system: "Medium pressure (MP) air system", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "30 min dry (*)", notes: ["Note 1"] },
+        { id: "misc_air_lp", group: "Miscellaneous", system: "Low pressure (LP) air system", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "Fire endurance test not required", notes: ["Note 1"] },
+        { id: "misc_service_air_nonessential", group: "Miscellaneous", system: "Service air (non‑essential)", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "dry", fireTest: "Fire endurance test not required" },
+        { id: "misc_brine", group: "Miscellaneous", system: "Brine", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: true }, pipeSystemClass: "wet", fireTest: "Fire endurance test not required" },
+        { id: "misc_co2", group: "Miscellaneous", system: "CO₂ system", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: false }, pipeSystemClass: "dry", fireTest: "30 min dry (*)", notes: ["Note 1"] },
+        { id: "misc_n2", group: "Miscellaneous", system: "Nitrogen system", mediumGroup: "other_media", allowed: { pipeUnions: true, compression: true, slipOn: false }, pipeSystemClass: "dry", fireTest: "30 min dry (*)" },
+        { id: "misc_steam", group: "Miscellaneous", system: "Steam", mediumGroup: "steam", allowed: { pipeUnions: true, compression: true, slipOn: false }, pipeSystemClass: "-", fireTest: "Fire endurance test not required", notes: ["See Note 5 / special consideration"] },
+      ];
+
+      const COUPLING_RULES = {
+        pipeUnions: (clazz, odMM) => {
+          if (clazz === "III") return { allowed: true, reason: "+ (sin límite de OD en Class III)" };
+          const ok = odMM <= 60.3;
+          return { allowed: ok, reason: ok ? "+ (OD ≤ 60.3 mm en Class I/II)" : "Table 1.5.4: En Class I/II solo OD ≤ 60.3 mm" };
+        },
+        compressionSubtypes: (clazz, odMM) => ({
+          swage: clazz === "III",
+          bite: clazz === "III" ? true : odMM <= 60.3,
+          typical: clazz === "III" ? true : odMM <= 60.3,
+          flared: clazz === "III" ? true : odMM <= 60.3,
+          press: clazz === "III",
+        }),
+        slipOnSubtypes: (clazz) => ({
+          machine_grooved: true,
+          grip: clazz !== "I",
+          slip: clazz !== "I",
+        }),
+      };
+
+      const [selectedSystemId, setSelectedSystemId] = useState(NAVAL_SYSTEMS[0].id);
+      const [classMode, setClassMode] = useState("manual");
+      const [clazz, setClazz] = useState("II");
+      const [odMM, setOdMM] = useState(50);
+      const [designPressureBar, setDesignPressureBar] = useState(7.5);
+      const [designTemperatureC, setDesignTemperatureC] = useState(25);
+      const [space, setSpace] = useState("other_machinery");
+      const [belowWTI, setBelowWTI] = useState(false);
+      const [insideTank, setInsideTank] = useState(false);
+      const [sameMediumTank, setSameMediumTank] = useState(false);
+      const [evaluation, setEvaluation] = useState(null);
+      const [viewer, setViewer] = useState(null);
+
+      function suggestClass(mediumGroup, P, T) {
+        const lim = CLASS_LIMITS[mediumGroup];
+        if (!lim) return "II";
+        if (P > lim.classII.P || T > lim.classII.T) return "I";
+        if (P > lim.classIII.P || T > lim.classIII.T) return "II";
+        return "III";
+      }
+
+      function computeUsedClass(sys) {
+        if (classMode === "manual") return clazz;
+        return suggestClass(sys.mediumGroup, designPressureBar, designTemperatureC);
+      }
+
+      function expandSystemNotes(notes) {
+        if (!notes) return [];
+        const out = [];
+        for (const n of notes) {
+          const nums = n.match(/[0-9]+/g) || [];
+          for (const code of nums) {
+            if (TABLE_NOTES_ES[code]) out.push(`Nota ${code}: ${TABLE_NOTES_ES[code]}`);
+          }
+        }
+        return out;
+      }
+
+      function buildComplianceNotes(sys, usedClass, catNotes) {
+        const notes = [];
+        if (sys.fireTest && !/not required/i.test(sys.fireTest)) {
+          notes.push(`Requiere ensayo de resistencia al fuego: ${sys.fireTest}.`);
+          notes.push("La junta seleccionada debe ser de tipo **resistente al fuego aprobado**.");
+        } else {
+          notes.push(`Ensayo de resistencia al fuego: **no requerido** (según la fila del sistema).`);
+        }
+
+        notes.push(...expandSystemNotes(sys.notes));
+
+        if (space === "other_machinery") {
+          notes.push("Si se emplean slip‑on joints en este espacio: deben estar en **posiciones visibles y accesibles** (Nota 2).");
+        }
+
+        if (["cargo_hold", "tank"].includes(space)) {
+          if (!(insideTank && sameMediumTank)) notes.push("5.10.9: Slip‑on joints no en bodegas/tanques o espacios no accesibles; dentro de tanques solo si el medio es el mismo.");
+        }
+
+        notes.push("5.10.10: El tipo Slip no debe usarse como medio principal de conexión (salvo compensación axial).");
+        notes.push("5.10.5: Las juntas mecánicas deben resistir presión de rotura ≥ 4 × presión de diseño.");
+        notes.push("5.10.12: Ensayos de tipo conforme a LR Type Approval Test Spec No. 2, según servicio.");
+
+        if (belowWTI) notes.push("5.10.6: Prohibidas juntas mecánicas si el tramo está conectado directamente al costado por debajo del límite de integridad estanca.");
+
+        const isSteam = sys.system.toLowerCase() === "steam" || sys.mediumGroup === "steam";
+        if (isSteam && designPressureBar <= 10 && space === "open_deck") notes.push("5.10.11: En buques tanque (oil/chemical), permitido 'restrained slip‑on' para vapor ≤ 10 bar en cubierta expuesta para absorber movimiento axial.");
+
+        notes.push(`Clase utilizada: Class ${usedClass}${classMode === "auto" ? " (derivada por P/T)" : " (seleccionada por usuario)"}.`);
+
+        notes.push(...catNotes);
+        return notes;
+      }
+
+      function evaluate() {
+        const sys = NAVAL_SYSTEMS.find((s) => s.id === selectedSystemId) || NAVAL_SYSTEMS[0];
+        const usedClass = computeUsedClass(sys);
+
+        const base = { ...sys.allowed };
+
+        const allowAfterLocation = { ...base };
+        const catNotes = [];
+
+        if (belowWTI) {
+          const reasons = ["5.10.6: Prohibido en tramos directamente conectados al costado por debajo del límite de integridad estanca."];
+          setEvaluation({ sys, usedClass, categories: { pipeUnions: false, compression: false, slipOn: false }, reasons, details: {}, notes: buildComplianceNotes(sys, usedClass, catNotes) });
+          return;
+        }
+
+        if (["category_a", "accommodation", "munition_store"].includes(space)) {
+          allowAfterLocation.slipOn = false;
+          catNotes.push("Nota 2: Slip‑on bloqueado por la ubicación seleccionada.");
+        }
+        if (["cargo_hold", "tank"].includes(space) && !(insideTank && sameMediumTank)) {
+          allowAfterLocation.slipOn = false;
+          catNotes.push("5.10.9: Slip‑on bloqueado en bodegas/tanques (salvo mismo medio dentro del tanque).");
+        }
+
+        let pipeUnionsAllowed = allowAfterLocation.pipeUnions;
+        let pipeUnionsRule = { allowed: false, reason: "" };
+        if (pipeUnionsAllowed) {
+          pipeUnionsRule = COUPLING_RULES.pipeUnions(usedClass, odMM);
+          pipeUnionsAllowed = pipeUnionsAllowed && pipeUnionsRule.allowed;
+          if (!pipeUnionsRule.allowed) catNotes.push(pipeUnionsRule.reason);
+        }
+
+        let compressionAllowed = allowAfterLocation.compression;
+        let compressionSubs = { swage: false, bite: false, typical: false, flared: false, press: false };
+        if (compressionAllowed) {
+          compressionSubs = COUPLING_RULES.compressionSubtypes(usedClass, odMM);
+          const anySub = Object.values(compressionSubs).some(Boolean);
+          compressionAllowed = compressionAllowed && anySub;
+          if (!anySub) catNotes.push(`Table 1.5.4: En Class ${usedClass}${usedClass !== "III" ? ` y OD ${odMM} mm` : ""} no queda ningún subtipo de compression permitido.`);
+          if (usedClass !== "III" && odMM > 60.3) catNotes.push("Table 1.5.4: En Class I/II, Bite/Typical/Flared solo OD ≤ 60.3mm.");
+          if (usedClass !== "III") catNotes.push("Table 1.5.4: Swage/Press solo en Class III.");
+        }
+
+        let slipOnAllowed = allowAfterLocation.slipOn;
+        let slipOnSubs = { machine_grooved: false, grip: false, slip: false };
+        if (slipOnAllowed) {
+          slipOnSubs = COUPLING_RULES.slipOnSubtypes(usedClass);
+          const anySub = Object.values(slipOnSubs).some(Boolean);
+          slipOnAllowed = slipOnAllowed && anySub;
+          if (!slipOnSubs.grip || !slipOnSubs.slip) catNotes.push("Table 1.5.4: Grip/Slip no se permiten en Class I.");
+        }
+
+        const categories = { pipeUnions: pipeUnionsAllowed, compression: compressionAllowed, slipOn: slipOnAllowed };
+
+        const details = {
+          pipeUnionsRule,
+          compressionSubs,
+          slipOnSubs,
+          odMM,
+          design: { P: designPressureBar, T: designTemperatureC },
+          classMode,
+          suggestedClass: suggestClass(sys.mediumGroup, designPressureBar, designTemperatureC),
+        };
+
+        const reasons = [];
+        if (!categories.slipOn && base.slipOn) reasons.push("Slip‑on permitido por 1.5.3, pero bloqueado por ubicación (Nota 2 / 5.10.9) o por clase en 1.5.4.");
+
+        setEvaluation({ sys, usedClass, categories, reasons, details, notes: buildComplianceNotes(sys, usedClass, catNotes) });
+      }
+
+      const sys = NAVAL_SYSTEMS.find((s) => s.id === selectedSystemId) || NAVAL_SYSTEMS[0];
+      const usedClass = computeUsedClass(sys);
+
+      return html`<div className="min-h-screen bg-gradient-to-b from-slate-900 to-slate-800 text-slate-100">
+        <header className="sticky top-0 z-10 backdrop-blur bg-slate-900/70 border-b border-slate-700">
+          <div className="max-w-7xl mx-auto px-4 py-3 flex items-center gap-3">
+            ${h(ShieldIcon, { className: "w-6 h-6" })}
+            <h1 className="text-xl font-semibold">Asesor Grip‑Type LR (Slip‑on Joints) – v0.7 · Naval Ships</h1>
+            <span className="ml-auto hidden md:block text-sm text-slate-300">Lógica: 1.5.3 → ubicación → 1.5.4 (clase/OD). Notas en español.</span>
+          </div>
+        </header>
+
+        <main className="max-w-7xl mx-auto p-4 space-y-6">
+          <section className="bg-slate-950/40 rounded-2xl p-4 shadow space-y-4">
+            <div className="grid md:grid-cols-2 gap-4">
+              <${Field} label="Sistema (Table 1.5.3)">
+                <select className="w-full bg-slate-800 border border-slate-600 rounded-xl px-3 py-2" value=${selectedSystemId} onChange=${(e) => setSelectedSystemId(e.target.value)}>
+                  ${Array.from(new Set(NAVAL_SYSTEMS.map((s) => s.group))).map(
+                    (grp) => html`<optgroup key=${grp} label=${grp}>
+                      ${NAVAL_SYSTEMS.filter((s) => s.group === grp).map(
+                        (s) => html`<option key=${s.id} value=${s.id}>${s.system}</option>`
+                      )}
+                    </optgroup>`
+                  )}
+                </select>
+              </${Field}>
+              <${Field} label="Espacio / Ubicación">
+                <select className="w-full bg-slate-800 border border-slate-600 rounded-xl px-3 py-2" value=${space} onChange=${(e) => setSpace(e.target.value)}>
+                  <option value="category_a">Category A machinery space</option>
+                  <option value="other_machinery">Other machinery/service spaces (accesible & visible)</option>
+                  <option value="accommodation">Accommodation spaces</option>
+                  <option value="munition_store">Munition stores</option>
+                  <option value="cargo_hold">Cargo hold</option>
+                  <option value="tank">Inside tank</option>
+                  <option value="open_deck">Open/Weather deck</option>
+                </select>
+              </${Field}>
+            </div>
+
+            <div className="grid md:grid-cols-2 gap-4">
+              <${Field} label="Modo de clase">
+                <div className="flex items-center gap-3">
+                  <button onClick=${() => setClassMode("manual")} className=${`px-3 py-1 rounded-full border ${classMode === "manual" ? "bg-slate-700 border-slate-500" : "border-slate-600"}`}>
+                    Seleccionar clase
+                  </button>
+                  <button onClick=${() => setClassMode("auto")} className=${`px-3 py-1 rounded-full border ${classMode === "auto" ? "bg-slate-700 border-slate-500" : "border-slate-600"}`}>
+                    Calcular por P/T
+                  </button>
+                  <span className="text-xs text-slate-400">Class I es la más exigente; usa AUTO si quieres derivarla desde P/T (Tabla 1.2.1).</span>
+                </div>
+              </${Field}>
+              ${
+                classMode === "manual"
+                  ? html`<${Field} label="Clase de tubería (Table 1.5.4)">
+                      <select className="w-full bg-slate-800 border border-slate-600 rounded-xl px-3 py-2" value=${clazz} onChange=${(e) => setClazz(e.target.value)}>
+                        <option value="I">Class I</option>
+                        <option value="II">Class II</option>
+                        <option value="III">Class III</option>
+                      </select>
+                    </${Field}>`
+                  : html`<div className="grid grid-cols-2 gap-3">
+                      <${Field} label="P diseño [bar]">
+                        <input type="number" step="0.1" className="w-full bg-slate-800 border border-slate-600 rounded-xl px-3 py-2" value=${designPressureBar} onChange=${(e) => setDesignPressureBar(Number(e.target.value))} />
+                      </${Field}>
+                      <${Field} label="T diseño [°C]">
+                        <input type="number" className="w-full bg-slate-800 border border-slate-600 rounded-xl px-3 py-2" value=${designTemperatureC} onChange=${(e) => setDesignTemperatureC(Number(e.target.value))} />
+                      </${Field}>
+                    </div>`
+              }
+            </div>
+
+            <div className="grid md:grid-cols-3 gap-4">
+              <${Field} label="Diámetro exterior OD [mm]">
+                <input type="number" className="w-full bg-slate-800 border border-slate-600 rounded-xl px-3 py-2" value=${odMM} onChange=${(e) => setOdMM(Number(e.target.value))} />
+              </${Field}>
+              <${Toggle} label="Conexión directa al costado por debajo del límite WTI (5.10.6)" value=${belowWTI} onChange=${setBelowWTI} />
+              <div className="grid grid-cols-2 gap-3">
+                <${Toggle} label="¿Dentro de tanque? (5.10.9)" value=${insideTank} onChange=${setInsideTank} />
+                <${Toggle} label="Si está en tanque: ¿medio igual al del tanque? (excepción 5.10.9)" value=${sameMediumTank} onChange=${setSameMediumTank} />
+              </div>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-3">
+              <button onClick=${evaluate} className="inline-flex items-center gap-2 bg-emerald-400 text-emerald-950 font-semibold px-3 py-2 rounded-xl hover:bg-emerald-300">
+                ${h(SearchIcon, { className: "w-4 h-4" })} Evaluar
+              </button>
+              <div className="text-xs text-slate-300">
+                Clase utilizada ahora: <b>Class ${usedClass}</b> ${classMode === "auto" ? `(calculada por P/T para ${sys.mediumGroup})` : ""}
+              </div>
+            </div>
+          </section>
+
+          <section className="bg-slate-950/40 rounded-2xl p-4 shadow space-y-4">
+            ${
+              !evaluation
+                ? html`<p className="text-slate-400 text-sm">Configura y pulsa Evaluar para ver las uniones permitidas y notas normativas (en español).</p>`
+                : html`<div className="space-y-4">
+                    <div className="text-sm text-slate-300">
+                      Sistema: <b>${evaluation.sys.group} → ${evaluation.sys.system}</b> · Condición del sistema (tabla): <b>${evaluation.sys.pipeSystemClass}</b> · Ensayo fuego: <b>${evaluation.sys.fireTest}</b>
+                    </div>
+
+                    <div className="grid md:grid-cols-3 gap-4">
+                      <${CategoryCard}
+                        title="Pipe unions"
+                        allowed=${evaluation.categories.pipeUnions}
+                        details=${evaluation.details.pipeUnionsRule?.reason}
+                        items=${[
+                          { label: "Welded/Brazed", kind: "pipe_welded_brazed", available: evaluation.categories.pipeUnions },
+                        ]}
+                        onView=${(kind) => setViewer({ open: true, title: "Pipe unions – welded/brazed", kind })}
+                      />
+
+                      <${CategoryCard}
+                        title="Compression couplings"
+                        allowed=${evaluation.categories.compression}
+                        details=${evaluation.categories.compression ? "Subtipos según clase y OD" : "Sin subtipos válidos con la clase/OD"}
+                        items=${[
+                          { label: "Swage", kind: "compression_swage", available: evaluation.details.compressionSubs.swage },
+                          { label: "Bite", kind: "compression_bite", available: evaluation.details.compressionSubs.bite },
+                          { label: "Typical", kind: "compression_typical", available: evaluation.details.compressionSubs.typical },
+                          { label: "Flared", kind: "compression_flared", available: evaluation.details.compressionSubs.flared },
+                          { label: "Press", kind: "compression_press", available: evaluation.details.compressionSubs.press },
+                        ]}
+                        onView=${(kind) => setViewer({ open: true, title: `Compression – ${kind.split("_")[1]}`, kind })}
+                      />
+
+                      <${CategoryCard}
+                        title="Slip‑on joints"
+                        allowed=${evaluation.categories.slipOn}
+                        details=${evaluation.categories.slipOn ? "Machine‑grooved / Grip / Slip" : "Bloqueado por ubicación o clase"}
+                        items=${[
+                          { label: "Machine grooved", kind: "slip_machine_grooved", available: evaluation.details.slipOnSubs.machine_grooved },
+                          { label: "Grip type", kind: "slip_grip", available: evaluation.details.slipOnSubs.grip },
+                          { label: "Slip type", kind: "slip_slip", available: evaluation.details.slipOnSubs.slip },
+                        ]}
+                        onView=${(kind) => setViewer({ open: true, title: `Slip‑on – ${kind.split("_")[1]}`, kind })}
+                      />
+                    </div>
+
+                    <div className="text-sm bg-slate-900 border border-slate-700 rounded-xl p-3">
+                      <div className="font-semibold mb-1">Notas y condiciones que aplican</div>
+                      <ul className="list-disc list-inside">
+                        ${evaluation.notes.map((n, i) => html`<li key=${i}>${n}</li>`)}
+                      </ul>
+                    </div>
+
+                    <div className="text-xs text-slate-400">
+                      Grupo de medio: <b>${sys.mediumGroup}</b>. Límites Class II: P≤${CLASS_LIMITS[sys.mediumGroup].classII.P} bar / T≤${CLASS_LIMITS[sys.mediumGroup].classII.T} °C; Class III: P≤${CLASS_LIMITS[sys.mediumGroup].classIII.P} bar / T≤${CLASS_LIMITS[sys.mediumGroup].classIII.T} °C. Si P/T superan Class II, norma exige Class I (2.3.2).
+                    </div>
+                  </div>`
+            }
+          </section>
+
+          <footer className="pb-10 text-xs text-slate-400">v0.7 • Naval Ships – Motor de decisión con notas en español y visor de referencias gráficas (SVG) por tipo de unión.</footer>
+        </main>
+
+        ${
+          viewer?.open
+            ? html`<div className="fixed inset-0 z-50 bg-black/70 flex items-center justify-center p-4" onClick=${() => setViewer(null)}>
+                <div className="bg-slate-900 border border-slate-700 rounded-2xl p-4 max-w-2xl w-full" onClick=${(e) => e.stopPropagation()}>
+                  <div className="flex items-center mb-3">
+                    <h3 className="text-lg font-semibold">${viewer.title}</h3>
+                    <button className="ml-auto px-3 py-1 rounded-lg bg-slate-800 border border-slate-600" onClick=${() => setViewer(null)}>
+                      Cerrar
+                    </button>
+                  </div>
+                  <div className="bg-slate-800 rounded-xl p-4 flex items-center justify-center">
+                    ${renderJointSVG(viewer.kind)}
+                  </div>
+                  <div className="text-xs text-slate-400 mt-2">Esquema referencial estilizado a partir de Fig. 1.5.4/1.5.5. Cuando dispongamos de las imágenes oficiales se sustituyen aquí sin cambiar el flujo.</div>
+                </div>
+              </div>`
+            : ""
+        }
+      </div>`;
+    }
+
+    function Field({ label, children }) {
+      return html`<label className="block text-sm">
+        <div className="mb-1 text-slate-300">${label}</div>
+        ${children}
+      </label>`;
+    }
+
+    function Toggle({ label, value, onChange }) {
+      const buttonClass = `w-12 h-7 rounded-full transition-colors ${value ? "bg-emerald-400" : "bg-slate-600"}`;
+      const knobClass = `block w-6 h-6 bg-white rounded-full mt-0.5 transition-transform ${value ? "translate-x-5" : "translate-x-1"}`;
+      return html`<div className="flex items-center justify-between px-3 py-2 bg-slate-800/60 border border-slate-600 rounded-xl">
+        <span className="text-sm text-slate-200">${label}</span>
+        <button onClick=${() => onChange(!value)} className=${buttonClass} aria-pressed=${value}>
+          <span className=${knobClass}></span>
+        </button>
+      </div>`;
+    }
+
+    function CategoryCard({ title, allowed, details, items, onView }) {
+      const wrapperClass = `rounded-xl p-3 border ${allowed ? "border-emerald-700 bg-emerald-900/20" : "border-rose-700 bg-rose-900/20"}`;
+      return html`<div className=${wrapperClass}>
+        <div className="font-semibold mb-1">${title}</div>
+        <div className="text-sm mb-2">
+          ${allowed ? "Se puede usar" : "No se puede usar"}${details ? html` • ${details}` : ""}
+        </div>
+        ${
+          items
+            ? html`<ul className="text-sm space-y-1">
+                ${items.map(
+                  (it, idx) => html`<li key=${idx} className="flex items-center gap-2">
+                    <span className=${it.available ? "" : "line-through opacity-60"}>${it.label}</span>
+                    ${
+                      it.available
+                        ? html`<button className="text-xs px-2 py-0.5 rounded-lg border border-slate-600 hover:bg-slate-700" onClick=${() => onView(it.kind)}>
+                            ver
+                          </button>`
+                        : ""
+                    }
+                  </li>`
+                )}
+              </ul>`
+            : ""
+        }
+      </div>`;
+    }
+
+    function renderJointSVG(kind) {
+      const common = { width: 520, height: 160, viewBox: "0 0 520 160" };
+      const line = (x1, y1, x2, y2, extra = {}) => h("line", { x1, y1, x2, y2, stroke: "white", strokeWidth: 3, ...extra });
+      const rect = (x, y, w, h, extra = {}) => h("rect", { x, y, width: w, height: h, fill: "none", stroke: "white", strokeWidth: 3, ...extra });
+      const path = (d, extra = {}) => h("path", { d, fill: "none", stroke: "white", strokeWidth: 3, ...extra });
+      switch (kind) {
+        case "pipe_welded_brazed":
+          return h("svg", common, line(40, 80, 240, 80), line(280, 80, 480, 80), path("M240 80 L260 50 L280 80"));
+        case "compression_swage":
+          return h("svg", common, line(40, 80, 200, 80), line(320, 80, 480, 80), rect(200, 60, 120, 40), path("M200 60 L210 40 L310 40 L320 60"));
+        case "compression_bite":
+          return h(
+            "svg",
+            common,
+            line(40, 80, 200, 80),
+            line(320, 80, 480, 80),
+            rect(200, 55, 120, 50),
+            path("M220 105 L220 55"),
+            path("M300 105 L300 55"),
+            path("M240 80 L280 80")
+          );
+        case "compression_typical":
+          return h("svg", common, line(40, 80, 200, 80), line(320, 80, 480, 80), rect(200, 55, 120, 50), rect(230, 40, 60, 30));
+        case "compression_flared":
+          return h("svg", common, line(40, 80, 210, 80), line(310, 80, 480, 80), path("M210 80 Q260 40 310 80"));
+        case "compression_press":
+          return h("svg", common, line(40, 90, 480, 90), rect(220, 50, 80, 40), path("M220 50 L210 30"), path("M300 50 L310 30"));
+        case "slip_machine_grooved":
+          return h("svg", common, line(40, 100, 480, 100), rect(210, 60, 100, 40), path("M210 60 L260 30 L310 60"));
+        case "slip_grip":
+          return h(
+            "svg",
+            common,
+            line(40, 100, 480, 100),
+            rect(200, 60, 120, 40),
+            path("M210 60 L260 30 L310 60"),
+            path("M220 85 Q260 65 300 85")
+          );
+        case "slip_slip":
+          return h("svg", common, line(40, 100, 480, 100), rect(210, 60, 100, 40), rect(230, 85, 60, 25));
+        default:
+          return html`<div className="text-slate-300">(Referencia no disponible)</div>`;
+      }
+    }
+
+    const root = ReactDOM.createRoot(document.getElementById("root"));
+    root.render(h(App));
+  </script>
+</body>
+</html>

--- a/asesor-grip-type.html
+++ b/asesor-grip-type.html
@@ -5,27 +5,28 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Asesor Grip-Type (Slip-on Joints) · LR Naval Ships</title>
 
-  <script src="https://cdn.tailwindcss.com"></script>
-
   <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          fontFamily: {
-            sans: ["Inter", "Segoe UI", "system-ui", "-apple-system", "sans-serif"],
+    tailwind = {
+      config: {
+        theme: {
+          extend: {
+            fontFamily: {
+              sans: ["Inter", "Segoe UI", "system-ui", "-apple-system", "sans-serif"],
+            },
           },
         },
       },
     };
   </script>
+  <script src="https://cdn.tailwindcss.com"></script>
 
-  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
-  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
   <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
 </head>
 <body class="bg-slate-900 text-slate-100 min-h-screen">
   <div class="p-4">
-    <a href="index.html" class="inline-flex items-center gap-2 text-sm text-sky-300 hover:text-sky-100">
+    <a href="./index.html" class="inline-flex items-center gap-2 text-sm text-sky-300 hover:text-sky-100">
       <span aria-hidden="true">←</span>
       Volver al inicio
     </a>

--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@
         <p>
           Evalúa si una línea puede atravesar un tanque o espacio específico según las tablas 11.5–11.8. Incluye cálculo de espesor mínimo por material y representación visual inmediata.
         </p>
-        <a class="btn primary" href="compatibilidad.html">
+        <a class="btn primary" href="./compatibilidad.html">
           <span>→</span> Abrir herramienta
         </a>
       </article>
@@ -147,7 +147,7 @@
         <p>
           Determina la viabilidad de juntas mecánicas Slip-on, Pipe Unions y Compression por sistema, clase y ubicación. Incluye notas normativas traducidas y visor ligero de esquemas SVG.
         </p>
-        <a class="btn secondary" href="asesor-grip-type.html">
+        <a class="btn secondary" href="./asesor-grip-type.html">
           <span>→</span> Explorar asesor
         </a>
       </article>


### PR DESCRIPTION
## Summary
- ensure the landing page cards link to the tools with explicit relative paths
- reorder the Grip-Type advisor head scripts to use production CDNs and fix the Tailwind config load order
- add a CSP-safe module version of the advisor together with a README that lists the verification steps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1cdac52c88321b4e7647032def7c3