### PR TITLE
Adapta compatibilidad a tema oscuro

### DIFF
--- a/compatibilidad.html
+++ b/compatibilidad.html
@@ -5,36 +5,233 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Compatibilidad de tuberías a través de tanques · Norma cerrada</title>
 <style>
-  :root{--ok:#16a34a;--bad:#dc2626;--warn:#d97706;--ink:#0f172a;--mut:#64748b;--bg:#f8fafc;--card:#ffffff}
-  html,body{margin:0;background:var(--bg);color:var(--ink);font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,'Helvetica Neue',Arial,'Noto Sans',sans-serif}
-  .wrap{max-width:1200px;margin:auto;padding:22px}
-  h1{font-size:22px;margin:0 0 8px}
-  .grid{display:grid;grid-template-columns:1.15fr 1fr;gap:18px}
-  .card{background:var(--card);border-radius:16px;box-shadow:0 10px 25px rgba(2,8,23,.06);padding:16px}
-  .row{display:grid;grid-template-columns:1fr 1fr;gap:10px}
-  label{font-size:12px;font-weight:700;color:#334155;display:block;margin-bottom:6px}
-  select,input{width:100%;padding:10px 12px;border:1px solid #e2e8f0;border-radius:10px;background:#fff;font-size:14px}
-  .hint{font-size:12px;color:var(--mut);margin-top:6px}
-  .pill{display:inline-flex;align-items:center;gap:6px;border-radius:999px;padding:6px 10px;font-weight:700;font-size:12px}
-  .pill.ok{background:#dcfce7;color:#065f46}
-  .pill.bad{background:#fee2e2;color:#991b1b}
-  .pill.warn{background:#fef3c7;color:#92400e}
-  .mono{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,'Liberation Mono',monospace}
-  .svgbox{position:relative;width:100%;aspect-ratio: 4/3;background:linear-gradient(180deg,#f1f5f9, #eef2ff)}
-  .legend{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px}
-  .tbl{width:100%;border-collapse:collapse;font-size:13px;margin-top:10px}
-  .tbl th,.tbl td{border:1px solid #e2e8f0;padding:8px}
-  .tbl th{background:#f1f5f9;text-align:left}
-  .small{font-size:12px;color:#475569}
-  .badge{display:inline-block;background:#eef2ff;color:#3730a3;border:1px solid #c7d2fe;padding:3px 6px;border-radius:999px;font-size:11px}
-  footer{margin-top:18px;font-size:12px;color:#475569}
-  .tests{font-size:12px;line-height:1.2}
-  .tests b{font-weight:800}
+  :root {
+    --bg: #0f172a;
+    --bg-soft: #1e293b;
+    --bg-card: rgba(15, 23, 42, 0.82);
+    --surface: rgba(15, 23, 42, 0.6);
+    --ink: #e2e8f0;
+    --ink-soft: rgba(226, 232, 240, 0.76);
+    --mut: rgba(148, 163, 184, 0.7);
+    --border: rgba(148, 163, 184, 0.18);
+    --accent: #38bdf8;
+    --accent-2: #a855f7;
+    --ok: #22c55e;
+    --bad: #f43f5e;
+    --warn: #f59e0b;
+  }
+  * { box-sizing: border-box; }
+  html, body {
+    margin: 0;
+    min-height: 100%;
+    background: radial-gradient(circle at top, #1e293b 0%, #0f172a 55%, #020617 100%);
+    color: var(--ink);
+    font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+  }
+  a { color: inherit; }
+  .wrap {
+    max-width: 1120px;
+    margin: 0 auto;
+    padding: 48px 24px 64px;
+  }
+  nav { margin-bottom: 28px; }
+  nav a {
+    color: var(--accent);
+    text-decoration: none;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    transition: color 0.2s ease;
+  }
+  nav a:hover { color: #7dd3fc; }
+  h1 {
+    font-size: clamp(26px, 4vw, 38px);
+    margin: 0 0 12px;
+    letter-spacing: -0.01em;
+  }
+  .small {
+    font-size: 14px;
+    color: var(--ink-soft);
+    margin: 0 0 24px;
+    max-width: 720px;
+    line-height: 1.6;
+  }
+  .grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
+    gap: 26px;
+    align-items: start;
+  }
+  .card {
+    background: var(--bg-card);
+    border-radius: 26px;
+    border: 1px solid var(--border);
+    padding: 28px;
+    box-shadow: 0 20px 45px rgba(2, 6, 23, 0.55);
+    backdrop-filter: blur(16px);
+  }
+  .card.result { position: sticky; top: 32px; }
+  .row {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 16px;
+  }
+  .row.row--spaced { margin-top: 18px; }
+  label {
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: rgba(226, 232, 240, 0.78);
+    margin-bottom: 8px;
+    display: block;
+  }
+  select, input[type="number"] {
+    width: 100%;
+    padding: 12px 14px;
+    border-radius: 14px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: var(--surface);
+    color: var(--ink);
+    font-size: 15px;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+  select:focus, input[type="number"]:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.3);
+    outline: none;
+  }
+  .hint {
+    font-size: 12px;
+    color: var(--mut);
+    margin-top: 6px;
+    line-height: 1.5;
+  }
+  .advanced-toggle {
+    margin-top: 16px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    color: var(--ink-soft);
+    font-size: 13px;
+  }
+  .advanced-toggle label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    font-weight: 600;
+    text-transform: none;
+    letter-spacing: 0;
+    margin-bottom: 0;
+  }
+  .advanced-toggle input[type="checkbox"] {
+    width: auto;
+    accent-color: var(--accent);
+  }
+  .pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    border-radius: 999px;
+    padding: 6px 12px;
+    font-weight: 700;
+    font-size: 13px;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+  }
+  .pill.ok { background: rgba(34, 197, 94, 0.18); color: #4ade80; border: 1px solid rgba(34, 197, 94, 0.45); }
+  .pill.bad { background: rgba(244, 63, 94, 0.15); color: #fb7185; border: 1px solid rgba(244, 63, 94, 0.45); }
+  .pill.warn { background: rgba(245, 158, 11, 0.16); color: #fcd34d; border: 1px solid rgba(245, 158, 11, 0.45); }
+  .legend { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 14px; }
+  .result-meta { margin-top: 18px; }
+  .result-meta h2 { margin-top: 0; }
+  .svgbox {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 4/3;
+    border-radius: 22px;
+    border: 1px solid var(--border);
+    background: radial-gradient(circle at 15% 20%, rgba(56, 189, 248, 0.14), transparent 55%),
+                linear-gradient(160deg, rgba(15, 23, 42, 0.85), rgba(15, 23, 42, 0.55));
+    overflow: hidden;
+  }
+  h2 { font-size: 22px; margin: 18px 0 10px; letter-spacing: -0.01em; }
+  .tbl {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 14px;
+    margin-top: 18px;
+    overflow: hidden;
+    border-radius: 16px;
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.15);
+  }
+  .tbl th, .tbl td { padding: 12px 14px; text-align: left; }
+  .tbl th {
+    background: rgba(148, 163, 184, 0.14);
+    color: var(--ink);
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    font-size: 12px;
+  }
+  .tbl td {
+    background: rgba(15, 23, 42, 0.45);
+    border-top: 1px solid rgba(148, 163, 184, 0.15);
+    color: var(--ink-soft);
+  }
+  .tbl tr:first-child td { border-top: none; }
+  .small strong { color: #fff; }
+  .badge {
+    display: inline-block;
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 600;
+    background: rgba(168, 85, 247, 0.18);
+    color: #c4b5fd;
+    border: 1px solid rgba(168, 85, 247, 0.35);
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+  details {
+    margin-top: 16px;
+    background: rgba(15, 23, 42, 0.55);
+    border-radius: 18px;
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    overflow: hidden;
+  }
+  summary {
+    cursor: pointer;
+    padding: 14px 18px;
+    font-weight: 600;
+  }
+  details[open] summary { border-bottom: 1px solid rgba(148, 163, 184, 0.2); }
+  details > div {
+    padding: 16px 18px;
+    font-size: 13px;
+    color: var(--ink-soft);
+    line-height: 1.5;
+  }
+  .tests { font-size: 13px; line-height: 1.5; color: var(--ink-soft); }
+  .tests b { color: #fff; }
+  footer {
+    margin-top: 32px;
+    font-size: 13px;
+    color: var(--mut);
+    line-height: 1.6;
+  }
+  @media (max-width: 940px) {
+    .grid { grid-template-columns: 1fr; }
+    .card.result { position: static; }
+  }
 </style>
 </head>
 <body>
 <div class="wrap">
-  <nav style="margin-bottom:18px"><a href="index.html" style="color:#2563eb;text-decoration:none;font-weight:600">← Volver al inicio</a></nav>
+  <nav><a href="index.html">← Volver al inicio</a></nav>
   <h1>¿Puede pasar una <em>tubería</em> a través de una <em>ubicación</em>?</h1>
   <p class="small">Norma referencia GL (Tabla 11.5) y espesores mínimos por material (Tablas 11.6–11.8). Resultado inmediato y visual.</p>
 
@@ -52,7 +249,7 @@
         </div>
       </div>
 
-      <div class="row" style="margin-top:10px">
+      <div class="row row--spaced">
         <div>
           <label>Material</label>
           <select id="material">
@@ -70,13 +267,13 @@
         </div>
       </div>
 
-      <div style="margin-top:10px;display:flex;align-items:center;gap:6px;flex-wrap:wrap">
-        <label style="display:flex;align-items:center;gap:6px;font-size:12px;color:#334155">
+      <div class="advanced-toggle">
+        <label>
           <input type="checkbox" id="allowDash"/> Permitir casos “–” (acuerdo especial) <span class="badge">avanzado</span>
         </label>
       </div>
 
-      <details style="margin-top:10px">
+      <details>
         <summary><strong>Autoverificación de lógica (tests unitarios)</strong></summary>
         <div id="tests" class="tests"></div>
       </details>
@@ -91,7 +288,7 @@
         <span class="pill warn">Especial (–)</span>
         <span class="badge">Visual: tanque + tubo</span>
       </div>
-      <div style="margin-top:10px">
+      <div class="result-meta">
         <h2 id="headline">—</h2>
         <div id="explain" class="small">—</div>
       </div>
@@ -193,19 +390,55 @@ function fill(id,arr){const el=document.getElementById(id);el.innerHTML='';arr.f
 
 function drawViz({status,place,system,s}){
   const svg=document.getElementById('viz');
-  const w=svg.clientWidth,h=svg.clientHeight,pad=24;
+  const w=svg.clientWidth||560;
+  const h=svg.clientHeight||420;
+  const pad=28;
   const tankX=pad,tankY=pad,tankW=w-pad*2,tankH=h-pad*2;
-  const pipeY=tankY+tankH*0.55;
+  const pipeH=Math.max(28,tankH*0.16);
+  const pipeY=tankY+tankH*0.58;
   const color=status==='ok'?'var(--ok)':status==='warn'?'var(--warn)':'var(--bad)';
+  const tankTop=status==='bad'?'#40202b':status==='warn'?'#3a2c15':'#1f2937';
+  const tankBottom=status==='bad'?'#1a0c12':status==='warn'?'#17100a':'#0b1120';
+  const icon=status==='ok'?'✔':status==='warn'?'!':'✖';
+  const note=status==='warn'?'Requiere acuerdo especial':status==='bad'?'Paso bloqueado':'Paso permitido';
+  const pipeStroke=status==='warn'?'stroke-dasharray="20 12" stroke-width="4"':'stroke-width="2.4"';
+  const filterId=status==='bad'?'glowBad':status==='warn'?'glowWarn':'glowOk';
   svg.innerHTML=`
-  <svg width="100%" height="100%" viewBox="0 0 ${w} ${h}" xmlns="http://www.w3.org/2000/svg">
-    <defs><linearGradient id="liq" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e0f2fe"/><stop offset="100%" stop-color="#bae6fd"/></linearGradient></defs>
-    <rect x="${tankX}" y="${tankY}" rx="18" ry="18" width="${tankW}" height="${tankH}" fill="url(#liq)" stroke="#0ea5e9" stroke-width="3"/>
-    <text x="${tankX+tankW/2}" y="${tankY+22}" text-anchor="middle" font-size="14" fill="#0f172a" font-weight="700">${place}</text>
-    <rect x="${tankX-40}" y="${pipeY-12}" width="${tankW+80}" height="24" rx="12" ry="12" fill="${color}" opacity="0.9"/>
-    <text x="${tankX+tankW/2}" y="${pipeY-20}" text-anchor="middle" font-size="13" fill="#0f172a">${system}</text>
-    ${status==='ok'&&s?`<text x="${tankX+tankW/2}" y="${pipeY+38}" text-anchor="middle" font-size="13" fill="#065f46">s = ${s.toFixed(1)} mm</text>`:''}
-    ${status==='bad'?`<line x1="${tankX+8}" y1="${tankY+8}" x2="${tankX+tankW-8}" y2="${tankY+tankH-8}" stroke="var(--bad)" stroke-width="6" opacity="0.8" /><line x1="${tankX+tankW-8}" y1="${tankY+8}" x2="${tankX+8}" y2="${tankY+tankH-8}" stroke="var(--bad)" stroke-width="6" opacity="0.8" />`:''}
+  <svg width="100%" height="100%" viewBox="0 0 ${w} ${h}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="${system} → ${place}">
+    <defs>
+      <linearGradient id="tankGrad" x1="0" y1="0" x2="0" y2="1">
+        <stop offset="0%" stop-color="${tankTop}" />
+        <stop offset="100%" stop-color="${tankBottom}" />
+      </linearGradient>
+      <linearGradient id="pipeGrad" x1="0" y1="0" x2="1" y2="0">
+        <stop offset="0%" stop-color="${color}" stop-opacity="0.55" />
+        <stop offset="50%" stop-color="${color}" stop-opacity="1" />
+        <stop offset="100%" stop-color="${color}" stop-opacity="0.55" />
+      </linearGradient>
+      <filter id="glowOk" x="-40%" y="-40%" width="180%" height="180%">
+        <feDropShadow dx="0" dy="0" stdDeviation="8" flood-color="#22c55e" flood-opacity="0.65"/>
+      </filter>
+      <filter id="glowWarn" x="-40%" y="-40%" width="180%" height="180%">
+        <feDropShadow dx="0" dy="0" stdDeviation="8" flood-color="#f59e0b" flood-opacity="0.6"/>
+      </filter>
+      <filter id="glowBad" x="-40%" y="-40%" width="180%" height="180%">
+        <feDropShadow dx="0" dy="0" stdDeviation="9" flood-color="#f43f5e" flood-opacity="0.7"/>
+      </filter>
+    </defs>
+    <rect x="${tankX}" y="${tankY}" rx="28" ry="28" width="${tankW}" height="${tankH}" fill="url(#tankGrad)" stroke="rgba(148,163,184,0.35)" stroke-width="2.2"/>
+    <text x="${tankX+tankW/2}" y="${tankY+36}" text-anchor="middle" font-size="16" font-weight="700" fill="rgba(226,232,240,0.88)">${place}</text>
+    <g filter="url(#${filterId})">
+      <rect x="${tankX-52}" y="${pipeY-pipeH/2}" width="${tankW+104}" height="${pipeH}" rx="${pipeH/2}" fill="url(#pipeGrad)" stroke="${color}" ${pipeStroke} opacity="0.95"/>
+    </g>
+    <text x="${tankX+tankW/2}" y="${pipeY-pipeH/2-14}" text-anchor="middle" font-size="13" fill="rgba(226,232,240,0.78)">${system}</text>
+    ${s&&status==='ok'?`<text x="${tankX+tankW/2}" y="${pipeY+pipeH/2+24}" text-anchor="middle" font-size="14" fill="#4ade80">s = ${s.toFixed(1)} mm</text>`:''}
+    <g transform="translate(${tankX+tankW-58}, ${tankY+22})">
+      <circle cx="18" cy="18" r="18" fill="rgba(15,23,42,0.7)" stroke="${color}" stroke-width="2"/>
+      <text x="18" y="23" text-anchor="middle" font-size="18" fill="${color}" font-weight="700">${icon}</text>
+    </g>
+    <text x="${tankX+36}" y="${tankY+tankH-28}" font-size="12" fill="rgba(226,232,240,0.64)">${note}</text>
+    ${status==='bad'?`<line x1="${tankX+18}" y1="${tankY+18}" x2="${tankX+tankW-18}" y2="${tankY+tankH-18}" stroke="${color}" stroke-width="6" stroke-linecap="round" opacity="0.72"/>`:''}
+    ${status==='bad'?`<line x1="${tankX+tankW-18}" y1="${tankY+18}" x2="${tankX+18}" y2="${tankY+tankH-18}" stroke="${color}" stroke-width="6" stroke-linecap="round" opacity="0.72"/>`:''}
   </svg>`;
 }
 


### PR DESCRIPTION
## Summary
- actualicé compatibilidad.html para usar una estética oscura y consistente con la portada
- refresqué controles, leyendas y ayudas con tipografía y componentes acorde al nuevo tema
- renové la visualización SVG del tanque y la tubería resaltando estados permitido, bloqueado y especial

## Testing
- no se ejecutaron pruebas (no aplicaba)


------
https://chatgpt.com/codex/tasks/task_e_68d2aa94f24883218178d29676793b2e